### PR TITLE
s/entrypoints/entryPoints/ for traefik crd

### DIFF
--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -93,8 +93,8 @@ ingress:
 
     # matchOverride: Host(`auth.example.com`) && PathPrefix(`/`)
 
-    entrypoints: []
-    # entrypoints:
+    entryPoints: []
+    # entryPoints:
     # - http
 
     # priority: 10


### PR DESCRIPTION
The template expects this camel cased, not sure which way is preferred long term, but at least this makes the doc match the code.