### PR TITLE
feat(authelia): hashicorp vault injector

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
   email: james-d-elliott@users.noreply.github.com
   url: https://github.com/james-d-elliott
 icon: https://avatars2.githubusercontent.com/u/59122411?s=200&v=4
-appVersion: 4.27.3
+appVersion: 4.27.4
 deprecated: false
 annotations: {}

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,28 +1,28 @@
 apiVersion: v2
 name: authelia
-version: 0.2.15
+version: 0.3.0
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
 keywords:
-  - SSO
-  - Authentication
-  - Security
-  - Two-Factor
-  - U2F
-  - YubiKey
-  - Push Notifications
-  - LDAP
+- SSO
+- Authentication
+- Security
+- Two-Factor
+- U2F
+- YubiKey
+- Push Notifications
+- LDAP
 home: https://www.authelia.com
 sources:
-  - https://github.com/authelia/chartrepo/tree/master/charts/authelia
-  - https://www.github.com/authelia/authelia
+- https://github.com/authelia/chartrepo/tree/master/charts/authelia
+- https://www.github.com/authelia/authelia
 dependencies: []
 maintainers:
-  - name: james-d-elliott
-    email: james-d-elliott@users.noreply.github.com
-    url: https://github.com/james-d-elliott
+- name: james-d-elliott
+  email: james-d-elliott@users.noreply.github.com
+  url: https://github.com/james-d-elliott
 icon: https://avatars2.githubusercontent.com/u/59122411?s=200&v=4
-appVersion: 4.27.2
+appVersion: 4.27.3
 deprecated: false
 annotations: {}

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -18,6 +18,115 @@ sections:
   in [the documentation](https://www.authelia.com/docs/configuration))
 - secret section to setup passwords and other secret information, configuring this directly is not supported
 
+# Parameters
+
+This documents the parameters in the chart values. As the chart values are quite large, we've split it into sections.
+
+## General
+
+|Parameter              |Description                                            |Default           |
+|:---------------------:|:-----------------------------------------------------:|:----------------:|
+|image.registry         |The container registry to use when pulling the image   |docker.io         |
+|image.repository       |The registry repository to use when pulling the image  |authelia/authelia |
+|image.tag              |The image tag to pull                                  |(latest supported)|
+|image.pullSecrets      |The k8s secret names to use for the pullSecrets        |[]                |
+|nameOverride           |To be refactored                                       |nil               |
+|appNameOverride        |To be refactored                                       |nil               |
+|annotations            |A map of extra annotations to add to all manifests     |{}                |
+|labels                 |A map of extra labels to add to all manifests          |{}                |
+|rbac.enabled           |Enable creation of a ServiceAccount to bind to the pod |false             |
+|rbac.annotations       |Extra annotations to add to the ServiceAccount         |{}                |
+|rbac.labels            |Extra labels to add to the ServiceAccount              |{}                |
+|rbac.serviceAccountName|The name to use for the ServiceAccount                 |authelia          |
+|domain                 |The domain to use                                      |example.com       |
+|service.annotations    |Extra annotations to add to the service                |{}                |
+|service.labels         |Extra labels to add to the Service                     |{}                |
+|service.port           |The exposed port on the ClusterIP Service              |80                |
+|service.clusterIP      |The ClusterIP to assign to the Service                 |nil               |
+
+## Ingress
+
+To Document.
+
+## ConfigMap
+
+This section only documents the sections that are specific to the helm chart. The majority of this section of the
+values.yaml is based on the *Authelia* configuration. See the
+[Authelia documentation](https://www.authelia.com/docs/configuration/) for more information.
+
+|Parameter                                              |Description                                             |Default           |
+|:-----------------------------------------------------:|:------------------------------------------------------:|:----------------:|
+|configMap.enabled                                      |If true generates the ConfigMap, otherwise it doesn't   |true              |
+|configMap.annotations                                  |Extra annotations to add to the ConfigMap               |{}                |
+|configMap.labels                                       |Extra labels to add to the ConfigMap                    |{}                |
+|configMap.key                                          |The key inside the ConfigMap which contains the config  |configuration.yaml|
+|configMap.existingConfigMap                            |Instead of generating a ConfigMap refers to an existing |nil               |
+|configMap.duo_api.enabled                              |Enables the Duo integration when generating the config  |false             |
+|configMap.authentication_backend.ldap.enabled          |Enables LDAP auth when generating the config            |true              |
+|configMap.authentication_backend.file.enabled          |Enables file auth when generating the config            |false             |
+|configMap.session.redis.enabled                        |Enables redis session storage when generating the config|true              |
+|configMap.session.redis.enabledSecret                  |Forces redis password auth using a secret if true       |false             |
+|configMap.session.redis.high_availability.enabled      |Enables redis sentinel when generating the config       |false             |
+|configMap.session.redis.high_availability.enabledSecret|Forces sentinel password auth using a secret if true    |false             |
+|configMap.storage.local.enabled                        |Enables the SQLite3 storage provider                    |false             |
+|configMap.storage.mysql.enabled                        |Enables the MySQL storage provider                      |false             |
+|configMap.storage.postgres.enabled                     |Enables the PostgreSQL storage provider                 |true              |
+|configMap.notifier.filesystem.enabled                  |Enables the filesystem notification provider            |false             |
+|configMap.notifier.smtp.enabled                        |Enables the SMTP notification provider                  |true              |
+|configMap.notifier.smtp.enabledSecret                  |Forces smtp password auth using a secret if true        |false             |
+|configMap.identity_providers.oidc.enabled              |Enables the OpenID Connect Idp                          |false             |
+
+## Secret
+
+The secret section defines how the secret values are added to Authelia. All values that can be a secret are forced as
+secrets with this chart. There are likely ways around this but we do not recommend it. Most secrets are automatically
+and randomly generated if the value is not defined, however we recommend manually generating the secret and mapping the
+chart to it so sensitive material isn't leaked. Alternatively, use HashiCorp Vault.
+
+The `*` below can be one of any of the following values:
+
+- jwt
+- ldap
+- storage
+- session
+- duo
+- redis
+- redisSentinel
+- smtp
+- oidcPrivateKey
+- oidcHMACSecret
+
+### Standard Secret
+
+|Parameter                     |Description                                            |Default                |
+|:----------------------------:|:-----------------------------------------------------:|:---------------------:|
+|secret.annotations            |A map of extra annotations to add to the Secret        |{}                     |
+|secret.labels                 |A map of extra labels to add to the Secret             |{}                     |
+|secret.existingSecret         |The name of the existing Secret instead of generating  |nil                    |
+|secret.mountPath              |The path where to mount all of the secrets             |/config/secrets        |
+|secret.*.key                  |The key in the secret where the JWT token is stored    |varies                 |
+|secret.*.value                |The value to inject into this secret when generating   |nil                    |
+|secret.*.filename             |The filename of this secret within the mountPath       |varies                 |
+
+### HashiCorp Vault
+
+|Parameter                                   |Description                                             |Default                |
+|:------------------------------------------:|:------------------------------------------------------:|:---------------------:|
+|secret.annotations                          |A map of extra annotations to add to the pod for Vault  |{}                     |
+|secret.mountPath                            |The path where to mount all of the secrets              |/config/secrets        |
+|secret.vaultInjector.enabled                |Enables HashiCorp Vault Injector annotations            |false                  |
+|secret.vaultInjector.role                   |Vault role to use                                       |authelia               |
+|secret.vaultInjector.agent.status           |Value to inject to prevent further mutations            |update                 |
+|secret.vaultInjector.agent.configMap        |Name of configMap where the agent config can be found   |nil                    |
+|secret.vaultInjector.agent.image            |Customizes the image to use for the agent               |nil                    |
+|secret.vaultInjector.agent.initFirst        |Configures the agent to init first if true              |false                  |
+|secret.vaultInjector.agent.command          |Configures the default command to run on inject         |sh -c 'kill HUP $(pidof authelia)'|
+|secret.vaultInjector.agent.runAsSameUser    |Runs the agent as the same user as the pod              |true                   |
+|secret.vaultInjector.agent.templateValue    |Configures the default secret rendering template        |nil                    |
+|secret.vaultInjector.secrets.*.path         |Configures the vault path to obtain the secret from     |varies                 |
+|secret.vaultInjector.secrets.*.templateValue|Configures the secret rendering template for this secret|nil                    |
+|secret.vaultInjector.secrets.*.command      |Configures the secret post-render cmd for this secret   |nil                    |
+
 # TODO
 
 - CI:

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -201,7 +201,7 @@ Returns the injector annotations
 */}}
 {{- define "authelia.annotations.injector" -}}
     {{- if include "authelia.enabled.injector" . -}}
-    {{- with $vault := .Values.secret.vault_injector -}}
+    {{- with $vault := .Values.secret.vaultInjector -}}
 vault.hashicorp.com/agent-inject: "true"
 {{- if $vault.role }}
 vault.hashicorp.com/role: {{ default "authelia" $vault.role }}
@@ -268,13 +268,13 @@ vault.hashicorp.com/agent-inject-secret-template-redis: {{ default $vault.agent.
 vault.hashicorp.com/agent-inject-secret-command-redis: {{ $vault.secrets.redis.command }}
 {{- end }}
 {{- if and $.Values.configMap.session.redis.high_availability.enabled $.Values.configMap.session.redis.high_availability.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-redis-sentinel: {{ $vault.secrets.redis_sentinel.path }}
+vault.hashicorp.com/agent-inject-secret-redis-sentinel: {{ $vault.secrets.redisSentinel.path }}
 vault.hashicorp.com/agent-inject-file-redis-sentinel: {{ include "authelia.secret.path" (merge (dict "Secret" "redis-sentinel") $) }}
-{{- if or $vault.agent.templateValue $vault.secrets.redis_sentinel.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-redis-sentinel {{ default $vault.agent.templateValue $vault.secrets.redis_sentinel.templateValue }}
+{{- if or $vault.agent.templateValue $vault.secrets.redisSentinel.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-redis-sentinel {{ default $vault.agent.templateValue $vault.secrets.redisSentinel.templateValue }}
 {{- end }}
-{{- if $vault.secrets.redis_sentinel.command }}
-vault.hashicorp.com/agent-inject-secret-command-redis-sentinel: {{ $vault.secrets.redis_sentinel.command }}
+{{- if $vault.secrets.redisSentinel.command }}
+vault.hashicorp.com/agent-inject-secret-command-redis-sentinel: {{ $vault.secrets.redisSentinel.command }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -569,8 +569,8 @@ Returns if hashicorp injector is enabled
 */}}
 {{- define "authelia.enabled.injector" -}}
     {{- if .Values.secret -}}
-        {{- if .Values.secret.vault_injector -}}
-            {{- if .Values.secret.vault_injector.enabled -}}
+        {{- if .Values.secret.vaultInjector -}}
+            {{- if .Values.secret.vaultInjector.enabled -}}
                 {{- true -}}
             {{- end -}}
         {{- end -}}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -203,83 +203,103 @@ Returns the injector annotations
     {{- if include "authelia.enabled.injector" . -}}
 vault.hashicorp.com/role: {{ default "authelia" .Values.secret.vault_injector.role }}
 vault.hashicorp.com/agent-inject: "true"
-vault.hashicorp.com/agent-inject-status: {{ default "update" .Values.secret.vault_injector.status }}
-{{- if .Values.secret.vault_injector.command }}
-vault.hashicorp.com/agent-inject-command: {{ .Values.secret.vault_injector.command }}
+vault.hashicorp.com/agent-inject-status: {{ default "update" .Values.secret.vault_injector.agent.status }}
+{{- if .Values.secret.vault_injector.agent.configMap }}
+vault.hashicorp.com/agent-configmap: {{ .Values.secret.vault_injector.agent.configMap }}
 {{- end }}
-{{- if .Values.secret.vault_injector.templateValue }}
-vault.hashicorp.com/agent-inject-template: {{ .Values.secret.vault_injector.templateValue }}
+{{- if .Values.secret.vault_injector.agent.image }}
+vault.hashicorp.com/agent-image: {{ .Values.secret.vault_injector.agent.image }}
 {{- end }}
-vault.hashicorp.com/agent-inject-secret-JWT_TOKEN: {{ .Values.secret.vault_injector.secrets.jwt.path }}
+{{- if .Values.secret.vault_injector.agent.initFirst }}
+vault.hashicorp.com/agent-init-first: {{ .Values.secret.vault_injector.agent.initFirst }}
+{{- end }}
+{{- if .Values.secret.vault_injector.agent.command }}
+vault.hashicorp.com/agent-inject-command: {{ .Values.secret.vault_injector.agent.command }}
+{{- end }}
+{{- if .Values.secret.vault_injector.agent.templateValue }}
+vault.hashicorp.com/agent-inject-template: {{ .Values.secret.vault_injector.agent.templateValue }}
+{{- end }}
+vault.hashicorp.com/agent-inject-volume-path: /config/secrets
+vault.hashicorp.com/agent-inject-secret-jwt: {{ .Values.secret.vault_injector.secrets.jwt.path }}
+vault.hashicorp.com/agent-inject-file-jwt: JWT_TOKEN
 {{- if .Values.secret.vault_injector.secrets.jwt.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-JWT_TOKEN: {{ .Values.secret.vault_injector.secrets.jwt.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-jwt: {{ .Values.secret.vault_injector.secrets.jwt.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.jwt.command }}
-vault.hashicorp.com/agent-inject-secret-command-JWT_TOKEN: {{ .Values.secret.vault_injector.secrets.jwt.command }}
+vault.hashicorp.com/agent-inject-secret-command-jwt: {{ .Values.secret.vault_injector.secrets.jwt.command }}
 {{- end }}
-vault.hashicorp.com/agent-inject-secret-SESSION_ENCRYPTION_KEY: {{ .Values.secret.vault_injector.secrets.session.path }}
+vault.hashicorp.com/agent-inject-secret-session: {{ .Values.secret.vault_injector.secrets.session.path }}
+vault.hashicorp.com/agent-inject-file-session: SESSION_ENCRYPTION_KEY
 {{- if .Values.secret.vault_injector.secrets.session.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-SESSION_ENCRYPTION_KEY: {{ .Values.secret.vault_injector.secrets.session.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-session: {{ .Values.secret.vault_injector.secrets.session.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.session.command }}
-vault.hashicorp.com/agent-inject-secret-command-SESSION_ENCRYPTION_KEY: {{ .Values.secret.vault_injector.secrets.session.command }}
+vault.hashicorp.com/agent-inject-secret-command-session: {{ .Values.secret.vault_injector.secrets.session.command }}
 {{- end }}
 {{- if .Values.configMap.authentication_backend.ldap.enabled }}
-vault.hashicorp.com/agent-inject-secret-LDAP_PASSWORD: {{ .Values.secret.vault_injector.secrets.ldap.path }}
+vault.hashicorp.com/agent-inject-secret-ldap: {{ .Values.secret.vault_injector.secrets.ldap.path }}
+vault.hashicorp.com/agent-inject-file-ldap: LDAP_PASSWORD
 {{- if .Values.secret.vault_injector.secrets.ldap.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-LDAP_PASSWORD: {{ .Values.secret.vault_injector.secrets.ldap.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-ldap: {{ .Values.secret.vault_injector.secrets.ldap.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.ldap.command }}
-vault.hashicorp.com/agent-inject-secret-command-LDAP_PASSWORD: {{ .Values.secret.vault_injector.secrets.ldap.command }}
+vault.hashicorp.com/agent-inject-secret-command-ldap: {{ .Values.secret.vault_injector.secrets.ldap.command }}
 {{- end }}
 {{- end }}
 {{- if or .Values.configMap.storage.mysql.enabled .Values.configMap.storage.postgres.enabled }}
-vault.hashicorp.com/agent-inject-secret-STORAGE_PASSWORD: {{ .Values.secret.vault_injector.secrets.storage.path }}
+vault.hashicorp.com/agent-inject-secret-storage: {{ .Values.secret.vault_injector.secrets.storage.path }}
+vault.hashicorp.com/agent-inject-file-storage: STORAGE_PASSWORD
 {{- if .Values.secret.vault_injector.secrets.storage.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-STORAGE_PASSWORD: {{ .Values.secret.vault_injector.secrets.storage.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-storage: {{ .Values.secret.vault_injector.secrets.storage.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.storage.command }}
-vault.hashicorp.com/agent-inject-secret-command-STORAGE_PASSWORD: {{ .Values.secret.vault_injector.secrets.storage.command }}
+vault.hashicorp.com/agent-inject-secret-command-storage: {{ .Values.secret.vault_injector.secrets.storage.command }}
 {{- end }}
 {{- end }}
 {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-REDIS_PASSWORD: {{ .Values.secret.vault_injector.secrets.redis.path }}
+vault.hashicorp.com/agent-inject-secret-redis: {{ .Values.secret.vault_injector.secrets.redis.path }}
+vault.hashicorp.com/agent-inject-file-redis: REDIS_PASSWORD
 {{- if .Values.secret.vault_injector.secrets.redis.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-REDIS_PASSWORD: {{ .Values.secret.vault_injector.secrets.redis.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-redis: {{ .Values.secret.vault_injector.secrets.redis.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.redis.command }}
-vault.hashicorp.com/agent-inject-secret-command-REDIS_PASSWORD: {{ .Values.secret.vault_injector.secrets.redis.command }}
+vault.hashicorp.com/agent-inject-secret-command-redis: {{ .Values.secret.vault_injector.secrets.redis.command }}
 {{- end }}
 {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-REDIS_SENTINEL_PASSWORD: {{ .Values.secret.vault_injector.secrets.redis_sentinel.path }}
+vault.hashicorp.com/agent-inject-secret-redissentinel: {{ .Values.secret.vault_injector.secrets.redis_sentinel.path }}
+vault.hashicorp.com/agent-inject-file-redissentinel: REDIS_SENTINEL_PASSWORD
 {{- if .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-REDIS_SENTINEL_PASSWORD: {{ .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-redissentinel {{ .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.redis_sentinel.command }}
-vault.hashicorp.com/agent-inject-secret-command-REDIS_SENTINEL_PASSWORD: {{ .Values.secret.vault_injector.secrets.redis_sentinel.command }}
+vault.hashicorp.com/agent-inject-secret-command-redissentinel: {{ .Values.secret.vault_injector.secrets.redis_sentinel.command }}
 {{- end }}
 {{- end }}
 {{- end }}
 {{- if and .Values.configMap.notifier.smtp.enabled .Values.configMap.notifier.smtp.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-SMTP_PASSWORD: {{ .Values.secret.vault_injector.secrets.smtp.path }}
+vault.hashicorp.com/agent-inject-secret-smtp: {{ .Values.secret.vault_injector.secrets.smtp.path }}
+vault.hashicorp.com/agent-inject-file-smtp: SMTP_PASSWORD
 {{- if .Values.secret.vault_injector.secrets.smtp.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-SMTP_PASSWORD: {{ .Values.secret.vault_injector.secrets.smtp.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-smtp: {{ .Values.secret.vault_injector.secrets.smtp.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.smtp.command }}
-vault.hashicorp.com/agent-inject-secret-command-SMTP_PASSWORD: {{ .Values.secret.vault_injector.secrets.smtp.command }}
+vault.hashicorp.com/agent-inject-secret-command-smtp: {{ .Values.secret.vault_injector.secrets.smtp.command }}
 {{- end }}
 {{- end }}
 {{- if include "authelia.configured.duo" . }}
-vault.hashicorp.com/agent-inject-secret-DUO_API_KEY: {{ .Values.secret.vault_injector.secrets.duo.path }}
+vault.hashicorp.com/agent-inject-secret-duo: {{ .Values.secret.vault_injector.secrets.duo.path }}
+vault.hashicorp.com/agent-inject-file-duo: DUO_API_KEY
 {{- if .Values.secret.vault_injector.secrets.duo.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-DUO_API_KEY: {{ .Values.secret.vault_injector.secrets.duo.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-duo: {{ .Values.secret.vault_injector.secrets.duo.templateValue }}
 {{- end }}
 {{- if .Values.secret.vault_injector.secrets.duo.command }}
-vault.hashicorp.com/agent-inject-secret-command-DUO_API_KEY: {{ .Values.secret.vault_injector.secrets.duo.command }}
+vault.hashicorp.com/agent-inject-secret-command-duo: {{ .Values.secret.vault_injector.secrets.duo.command }}
 {{- end }}
 {{- end }}
-vault.hashicorp.com/agent-run-as-same-user: {{ default "true" .Values.secret.vault_injector.sameAsUser | quote }}
+vault.hashicorp.com/agent-run-as-same-user: {{ default "true" .Values.secret.vault_injector.agent.runAsSameUser | quote }}
+{{- if .Values.secret.annotations }}
 {{- toYaml .Values.secret.annotations | nindent 0 }}
+    {{- end }}
     {{- end }}
 {{- end -}}
 
@@ -291,17 +311,6 @@ Returns the value of .SecretValue or a randomly generated one
         {{- .SecretValue | b64enc -}}
     {{- else -}}
         {{- randAlphaNum 128 | b64enc -}}
-    {{- end -}}
-{{- end -}}
-
-{{/*
-Returns the correct secret path for env.
-*/}}
-{{- define "authelia.secret.path" -}}
-    {{- if include "authelia.enabled.injector" . -}}
-        {{- printf "/vault/secrets/%s" .Name -}}
-    {{- else -}}
-        {{- printf "/config/secrets/%s" .Name -}}
     {{- end -}}
 {{- end -}}
 

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -201,122 +201,121 @@ Returns the injector annotations
 */}}
 {{- define "authelia.annotations.injector" -}}
     {{- if include "authelia.enabled.injector" . -}}
-vault.hashicorp.com/role: {{ default "authelia" .Values.secret.vault_injector.role }}
+    {{- with $vault := .Values.secret.vault_injector }}
+vault.hashicorp.com/role: {{ default "authelia" $vault.role }}
 vault.hashicorp.com/agent-inject: "true"
-vault.hashicorp.com/agent-inject-status: {{ default "update" .Values.secret.vault_injector.agent.status }}
-{{- if .Values.secret.vault_injector.agent.configMap }}
-vault.hashicorp.com/agent-configmap: {{ .Values.secret.vault_injector.agent.configMap }}
+vault.hashicorp.com/agent-inject-status: {{ default "update" $vault.agent.status }}
+{{- if $vault.agent.configMap }}
+vault.hashicorp.com/agent-configmap: {{ $vault.agent.configMap }}
 {{- end }}
-{{- if .Values.secret.vault_injector.agent.image }}
-vault.hashicorp.com/agent-image: {{ .Values.secret.vault_injector.agent.image }}
+{{- if $vault.agent.image }}
+vault.hashicorp.com/agent-image: {{ $vault.agent.image }}
 {{- end }}
-{{- if .Values.secret.vault_injector.agent.initFirst }}
-vault.hashicorp.com/agent-init-first: {{ .Values.secret.vault_injector.agent.initFirst }}
+{{- if $vault.agent.initFirst }}
+vault.hashicorp.com/agent-init-first: {{ $vault.agent.initFirst }}
 {{- end }}
-{{- if .Values.secret.vault_injector.agent.command }}
-vault.hashicorp.com/agent-inject-command: {{ .Values.secret.vault_injector.agent.command }}
+{{- if $vault.agent.command }}
+vault.hashicorp.com/agent-inject-command: {{ $vault.agent.command }}
 {{- end }}
-{{- if .Values.secret.vault_injector.agent.templateValue }}
-vault.hashicorp.com/agent-inject-template: {{ .Values.secret.vault_injector.agent.templateValue }}
+vault.hashicorp.com/agent-inject-volume-path: {{ include "authelia.secret.mountPath" $ }}
+vault.hashicorp.com/agent-inject-secret-jwt: {{ $vault.secrets.jwt.path }}
+vault.hashicorp.com/agent-inject-file-jwt: {{ include "authelia.secret.path" (merge (dict "Secret" "jwt") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.jwt.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-jwt: {{ default $vault.agent.templateValue $vault.secrets.jwt.templateValue }}
 {{- end }}
-vault.hashicorp.com/agent-inject-volume-path: {{ include "authelia.secret.mountPath" . }}
-vault.hashicorp.com/agent-inject-secret-jwt: {{ .Values.secret.vault_injector.secrets.jwt.path }}
-vault.hashicorp.com/agent-inject-file-jwt: {{ include "authelia.secret.path" (merge (dict "Secret" "jwt") .) }}
-{{- if .Values.secret.vault_injector.secrets.jwt.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-jwt: {{ .Values.secret.vault_injector.secrets.jwt.templateValue }}
+{{- if $vault.secrets.jwt.command }}
+vault.hashicorp.com/agent-inject-secret-command-jwt: {{ $vault.secrets.jwt.command }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.jwt.command }}
-vault.hashicorp.com/agent-inject-secret-command-jwt: {{ .Values.secret.vault_injector.secrets.jwt.command }}
+vault.hashicorp.com/agent-inject-secret-session: {{ $vault.secrets.session.path }}
+vault.hashicorp.com/agent-inject-file-session: {{ include "authelia.secret.path" (merge (dict "Secret" "session") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.session.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-session: {{ default $vault.agent.templateValue $vault.secrets.session.templateValue }}
 {{- end }}
-vault.hashicorp.com/agent-inject-secret-session: {{ .Values.secret.vault_injector.secrets.session.path }}
-vault.hashicorp.com/agent-inject-file-session: {{ include "authelia.secret.path" (merge (dict "Secret" "session") .) }}
-{{- if .Values.secret.vault_injector.secrets.session.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-session: {{ .Values.secret.vault_injector.secrets.session.templateValue }}
+{{- if $vault.secrets.session.command }}
+vault.hashicorp.com/agent-inject-secret-command-session: {{ $vault.secrets.session.command }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.session.command }}
-vault.hashicorp.com/agent-inject-secret-command-session: {{ .Values.secret.vault_injector.secrets.session.command }}
+{{- if $.Values.configMap.authentication_backend.ldap.enabled }}
+vault.hashicorp.com/agent-inject-secret-ldap: {{ $vault.secrets.ldap.path }}
+vault.hashicorp.com/agent-inject-file-ldap: {{ include "authelia.secret.path" (merge (dict "Secret" "ldap") $) }}
+{{- if or $vault.secrets.ldap.templateValue $vault.agent.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-ldap: {{ default $vault.agent.templateValue $vault.secrets.ldap.templateValue }}
 {{- end }}
-{{- if .Values.configMap.authentication_backend.ldap.enabled }}
-vault.hashicorp.com/agent-inject-secret-ldap: {{ .Values.secret.vault_injector.secrets.ldap.path }}
-vault.hashicorp.com/agent-inject-file-ldap: {{ include "authelia.secret.path" (merge (dict "Secret" "ldap") .) }}
-{{- if .Values.secret.vault_injector.secrets.ldap.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-ldap: {{ .Values.secret.vault_injector.secrets.ldap.templateValue }}
-{{- end }}
-{{- if .Values.secret.vault_injector.secrets.ldap.command }}
-vault.hashicorp.com/agent-inject-secret-command-ldap: {{ .Values.secret.vault_injector.secrets.ldap.command }}
+{{- if $vault.secrets.ldap.command }}
+vault.hashicorp.com/agent-inject-secret-command-ldap: {{ $vault.secrets.ldap.command }}
 {{- end }}
 {{- end }}
-{{- if or .Values.configMap.storage.mysql.enabled .Values.configMap.storage.postgres.enabled }}
-vault.hashicorp.com/agent-inject-secret-storage: {{ .Values.secret.vault_injector.secrets.storage.path }}
-vault.hashicorp.com/agent-inject-file-storage: {{ include "authelia.secret.path" (merge (dict "Secret" "storage") .) }}
-{{- if .Values.secret.vault_injector.secrets.storage.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-storage: {{ .Values.secret.vault_injector.secrets.storage.templateValue }}
+{{- if or $.Values.configMap.storage.mysql.enabled $.Values.configMap.storage.postgres.enabled }}
+vault.hashicorp.com/agent-inject-secret-storage: {{ $vault.secrets.storage.path }}
+vault.hashicorp.com/agent-inject-file-storage: {{ include "authelia.secret.path" (merge (dict "Secret" "storage") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.storage.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-storage: {{ default $vault.agent.templateValue $vault.secrets.storage.templateValue }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.storage.command }}
-vault.hashicorp.com/agent-inject-secret-command-storage: {{ .Values.secret.vault_injector.secrets.storage.command }}
+{{- if $vault.secrets.storage.command }}
+vault.hashicorp.com/agent-inject-secret-command-storage: {{ $vault.secrets.storage.command }}
 {{- end }}
 {{- end }}
-{{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-redis: {{ .Values.secret.vault_injector.secrets.redis.path }}
-vault.hashicorp.com/agent-inject-file-redis: {{ include "authelia.secret.path" (merge (dict "Secret" "redis") .) }}
-{{- if .Values.secret.vault_injector.secrets.redis.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-redis: {{ .Values.secret.vault_injector.secrets.redis.templateValue }}
+{{- if and $.Values.configMap.session.redis.enabled $.Values.configMap.session.redis.enabledSecret }}
+vault.hashicorp.com/agent-inject-secret-redis: {{ $vault.secrets.redis.path }}
+vault.hashicorp.com/agent-inject-file-redis: {{ include "authelia.secret.path" (merge (dict "Secret" "redis") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.redis.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-redis: {{ default $vault.agent.templateValue $vault.secrets.redis.templateValue }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.redis.command }}
-vault.hashicorp.com/agent-inject-secret-command-redis: {{ .Values.secret.vault_injector.secrets.redis.command }}
+{{- if $vault.secrets.redis.command }}
+vault.hashicorp.com/agent-inject-secret-command-redis: {{ $vault.secrets.redis.command }}
 {{- end }}
-{{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-redissentinel: {{ .Values.secret.vault_injector.secrets.redis_sentinel.path }}
-vault.hashicorp.com/agent-inject-file-redissentinel: {{ include "authelia.secret.path" (merge (dict "Secret" "redis-sentinel") .) }}
-{{- if .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-redissentinel {{ .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
+{{- if and $.Values.configMap.session.redis.high_availability.enabled $.Values.configMap.session.redis.high_availability.enabledSecret }}
+vault.hashicorp.com/agent-inject-secret-redis-sentinel: {{ $vault.secrets.redis_sentinel.path }}
+vault.hashicorp.com/agent-inject-file-redis-sentinel: {{ include "authelia.secret.path" (merge (dict "Secret" "redis-sentinel") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.redis_sentinel.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-redis-sentinel {{ default $vault.agent.templateValue $vault.secrets.redis_sentinel.templateValue }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.redis_sentinel.command }}
-vault.hashicorp.com/agent-inject-secret-command-redissentinel: {{ .Values.secret.vault_injector.secrets.redis_sentinel.command }}
+{{- if $vault.secrets.redis_sentinel.command }}
+vault.hashicorp.com/agent-inject-secret-command-redis-sentinel: {{ $vault.secrets.redis_sentinel.command }}
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.configMap.notifier.smtp.enabled .Values.configMap.notifier.smtp.enabledSecret }}
-vault.hashicorp.com/agent-inject-secret-smtp: {{ .Values.secret.vault_injector.secrets.smtp.path }}
-vault.hashicorp.com/agent-inject-file-smtp: {{ include "authelia.secret.path" (merge (dict "Secret" "smtp") .) }}
-{{- if .Values.secret.vault_injector.secrets.smtp.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-smtp: {{ .Values.secret.vault_injector.secrets.smtp.templateValue }}
+{{- if and $.Values.configMap.notifier.smtp.enabled $.Values.configMap.notifier.smtp.enabledSecret }}
+vault.hashicorp.com/agent-inject-secret-smtp: {{ $vault.secrets.smtp.path }}
+vault.hashicorp.com/agent-inject-file-smtp: {{ include "authelia.secret.path" (merge (dict "Secret" "smtp") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.smtp.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-smtp: {{ default $vault.agent.templateValue $vault.secrets.smtp.templateValue }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.smtp.command }}
-vault.hashicorp.com/agent-inject-secret-command-smtp: {{ .Values.secret.vault_injector.secrets.smtp.command }}
-{{- end }}
-{{- end }}
-{{- if include "authelia.configured.duo" . }}
-vault.hashicorp.com/agent-inject-secret-duo: {{ .Values.secret.vault_injector.secrets.duo.path }}
-vault.hashicorp.com/agent-inject-file-duo: {{ include "authelia.secret.path" (merge (dict "Secret" "duo") .) }}
-{{- if .Values.secret.vault_injector.secrets.duo.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-duo: {{ .Values.secret.vault_injector.secrets.duo.templateValue }}
-{{- end }}
-{{- if .Values.secret.vault_injector.secrets.duo.command }}
-vault.hashicorp.com/agent-inject-secret-command-duo: {{ .Values.secret.vault_injector.secrets.duo.command }}
+{{- if $vault.secrets.smtp.command }}
+vault.hashicorp.com/agent-inject-secret-command-smtp: {{ $vault.secrets.smtp.command }}
 {{- end }}
 {{- end }}
-{{- if .Values.configMap.identity_providers.oidc.enabled }}
-vault.hashicorp.com/agent-inject-secret-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.path }}
-vault.hashicorp.com/agent-inject-file-oidc-private-key: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-private-key") .) }}
-{{- if .Values.secret.vault_injector.secrets.oidcPrivateKey.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.templateValue }}
+{{- if include "authelia.configured.duo" $ }}
+vault.hashicorp.com/agent-inject-secret-duo: {{ $vault.secrets.duo.path }}
+vault.hashicorp.com/agent-inject-file-duo: {{ include "authelia.secret.path" (merge (dict "Secret" "duo") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.duo.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-duo: {{ default $vault.agent.templateValue $vault.secrets.duo.templateValue }}
 {{- end }}
-{{- if .Values.secret.vault_injector.secrets.oidcPrivateKey.command }}
-vault.hashicorp.com/agent-inject-secret-command-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.command }}
-{{- end }}
-vault.hashicorp.com/agent-inject-secret-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.path }}
-vault.hashicorp.com/agent-inject-file-oidc-hmac-secret: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-hmac-secret") .) }}
-{{- if .Values.secret.vault_injector.secrets.oidcHMACSecret.templateValue }}
-vault.hashicorp.com/agent-inject-secret-template-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.templateValue }}
-{{- end }}
-{{- if .Values.secret.vault_injector.secrets.oidcHMACSecret.command }}
-vault.hashicorp.com/agent-inject-secret-command-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.command }}
+{{- if $vault.secrets.duo.command }}
+vault.hashicorp.com/agent-inject-secret-command-duo: {{ $vault.secrets.duo.command }}
 {{- end }}
 {{- end }}
-vault.hashicorp.com/agent-run-as-same-user: {{ default "true" .Values.secret.vault_injector.agent.runAsSameUser | quote }}
-{{- if .Values.secret.annotations }}
-{{- toYaml .Values.secret.annotations | nindent 0 }}
+{{- if $.Values.configMap.identity_providers.oidc.enabled }}
+vault.hashicorp.com/agent-inject-secret-oidc-private-key: {{ $vault.secrets.oidcPrivateKey.path }}
+vault.hashicorp.com/agent-inject-file-oidc-private-key: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-private-key") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.oidcPrivateKey.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-oidc-private-key: {{ default $vault.agent.templateValue $vault.secrets.oidcPrivateKey.templateValue }}
+{{- end }}
+{{- if $vault.secrets.oidcPrivateKey.command }}
+vault.hashicorp.com/agent-inject-secret-command-oidc-private-key: {{ $vault.secrets.oidcPrivateKey.command }}
+{{- end }}
+vault.hashicorp.com/agent-inject-secret-oidc-hmac-secret: {{ $vault.secrets.oidcHMACSecret.path }}
+vault.hashicorp.com/agent-inject-file-oidc-hmac-secret: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-hmac-secret") $) }}
+{{- if or $vault.agent.templateValue $vault.secrets.oidcHMACSecret.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-oidc-hmac-secret: {{ default $vault.agent.templateValue $vault.secrets.oidcHMACSecret.templateValue }}
+{{- end }}
+{{- if $vault.secrets.oidcHMACSecret.command }}
+vault.hashicorp.com/agent-inject-secret-command-oidc-hmac-secret: {{ $vault.secrets.oidcHMACSecret.command }}
+{{- end }}
+{{- end }}
+vault.hashicorp.com/agent-run-as-same-user: {{ default "true" $vault.agent.runAsSameUser | quote }}
+{{- if $.Values.secret.annotations }}
+{{- toYaml $.Values.secret.annotations | nindent 0 }}
+    {{- end }}
     {{- end }}
     {{- end }}
 {{- end -}}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -201,11 +201,11 @@ Returns the injector annotations
 */}}
 {{- define "authelia.annotations.injector" -}}
     {{- if include "authelia.enabled.injector" . -}}
-    {{- with $vault := .Values.secret.vault_injector }}
+    {{- with $vault := .Values.secret.vault_injector -}}
+vault.hashicorp.com/agent-inject: "true"
 {{- if $vault.role }}
 vault.hashicorp.com/role: {{ default "authelia" $vault.role }}
 {{- end }}
-vault.hashicorp.com/agent-inject: "true"
 {{- if $vault.agent.status }}
 vault.hashicorp.com/agent-inject-status: {{ default "update" $vault.agent.status }}
 {{- end }}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -202,9 +202,13 @@ Returns the injector annotations
 {{- define "authelia.annotations.injector" -}}
     {{- if include "authelia.enabled.injector" . -}}
     {{- with $vault := .Values.secret.vault_injector }}
+{{- if $vault.role }}
 vault.hashicorp.com/role: {{ default "authelia" $vault.role }}
+{{- end }}
 vault.hashicorp.com/agent-inject: "true"
+{{- if $vault.agent.status }}
 vault.hashicorp.com/agent-inject-status: {{ default "update" $vault.agent.status }}
+{{- end }}
 {{- if $vault.agent.configMap }}
 vault.hashicorp.com/agent-configmap: {{ $vault.agent.configMap }}
 {{- end }}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -296,6 +296,24 @@ vault.hashicorp.com/agent-inject-secret-template-duo: {{ .Values.secret.vault_in
 vault.hashicorp.com/agent-inject-secret-command-duo: {{ .Values.secret.vault_injector.secrets.duo.command }}
 {{- end }}
 {{- end }}
+{{- if .Values.configMap.identity_providers.oidc.enabled }}
+vault.hashicorp.com/agent-inject-secret-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.path }}
+vault.hashicorp.com/agent-inject-file-oidc-private-key: OIDC_PRIVATE_KEY
+{{- if .Values.secret.vault_injector.secrets.oidcPrivateKey.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.templateValue }}
+{{- end }}
+{{- if .Values.secret.vault_injector.secrets.oidcPrivateKey.command }}
+vault.hashicorp.com/agent-inject-secret-command-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.command }}
+{{- end }}
+vault.hashicorp.com/agent-inject-secret-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.path }}
+vault.hashicorp.com/agent-inject-file-oidc-hmac-secret: OIDC_HMAC_SECRET
+{{- if .Values.secret.vault_injector.secrets.oidcHMACSecret.templateValue }}
+vault.hashicorp.com/agent-inject-secret-template-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.templateValue }}
+{{- end }}
+{{- if .Values.secret.vault_injector.secrets.oidcHMACSecret.command }}
+vault.hashicorp.com/agent-inject-secret-command-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.command }}
+{{- end }}
+{{- end }}
 vault.hashicorp.com/agent-run-as-same-user: {{ default "true" .Values.secret.vault_injector.agent.runAsSameUser | quote }}
 {{- if .Values.secret.annotations }}
 {{- toYaml .Values.secret.annotations | nindent 0 }}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -219,9 +219,9 @@ vault.hashicorp.com/agent-inject-command: {{ .Values.secret.vault_injector.agent
 {{- if .Values.secret.vault_injector.agent.templateValue }}
 vault.hashicorp.com/agent-inject-template: {{ .Values.secret.vault_injector.agent.templateValue }}
 {{- end }}
-vault.hashicorp.com/agent-inject-volume-path: /config/secrets
+vault.hashicorp.com/agent-inject-volume-path: {{ include "authelia.secret.mountPath" . }}
 vault.hashicorp.com/agent-inject-secret-jwt: {{ .Values.secret.vault_injector.secrets.jwt.path }}
-vault.hashicorp.com/agent-inject-file-jwt: JWT_TOKEN
+vault.hashicorp.com/agent-inject-file-jwt: {{ include "authelia.secret.path" (merge (dict "Secret" "jwt") .) }}
 {{- if .Values.secret.vault_injector.secrets.jwt.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-jwt: {{ .Values.secret.vault_injector.secrets.jwt.templateValue }}
 {{- end }}
@@ -229,7 +229,7 @@ vault.hashicorp.com/agent-inject-secret-template-jwt: {{ .Values.secret.vault_in
 vault.hashicorp.com/agent-inject-secret-command-jwt: {{ .Values.secret.vault_injector.secrets.jwt.command }}
 {{- end }}
 vault.hashicorp.com/agent-inject-secret-session: {{ .Values.secret.vault_injector.secrets.session.path }}
-vault.hashicorp.com/agent-inject-file-session: SESSION_ENCRYPTION_KEY
+vault.hashicorp.com/agent-inject-file-session: {{ include "authelia.secret.path" (merge (dict "Secret" "session") .) }}
 {{- if .Values.secret.vault_injector.secrets.session.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-session: {{ .Values.secret.vault_injector.secrets.session.templateValue }}
 {{- end }}
@@ -238,7 +238,7 @@ vault.hashicorp.com/agent-inject-secret-command-session: {{ .Values.secret.vault
 {{- end }}
 {{- if .Values.configMap.authentication_backend.ldap.enabled }}
 vault.hashicorp.com/agent-inject-secret-ldap: {{ .Values.secret.vault_injector.secrets.ldap.path }}
-vault.hashicorp.com/agent-inject-file-ldap: LDAP_PASSWORD
+vault.hashicorp.com/agent-inject-file-ldap: {{ include "authelia.secret.path" (merge (dict "Secret" "ldap") .) }}
 {{- if .Values.secret.vault_injector.secrets.ldap.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-ldap: {{ .Values.secret.vault_injector.secrets.ldap.templateValue }}
 {{- end }}
@@ -248,7 +248,7 @@ vault.hashicorp.com/agent-inject-secret-command-ldap: {{ .Values.secret.vault_in
 {{- end }}
 {{- if or .Values.configMap.storage.mysql.enabled .Values.configMap.storage.postgres.enabled }}
 vault.hashicorp.com/agent-inject-secret-storage: {{ .Values.secret.vault_injector.secrets.storage.path }}
-vault.hashicorp.com/agent-inject-file-storage: STORAGE_PASSWORD
+vault.hashicorp.com/agent-inject-file-storage: {{ include "authelia.secret.path" (merge (dict "Secret" "storage") .) }}
 {{- if .Values.secret.vault_injector.secrets.storage.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-storage: {{ .Values.secret.vault_injector.secrets.storage.templateValue }}
 {{- end }}
@@ -258,7 +258,7 @@ vault.hashicorp.com/agent-inject-secret-command-storage: {{ .Values.secret.vault
 {{- end }}
 {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
 vault.hashicorp.com/agent-inject-secret-redis: {{ .Values.secret.vault_injector.secrets.redis.path }}
-vault.hashicorp.com/agent-inject-file-redis: REDIS_PASSWORD
+vault.hashicorp.com/agent-inject-file-redis: {{ include "authelia.secret.path" (merge (dict "Secret" "redis") .) }}
 {{- if .Values.secret.vault_injector.secrets.redis.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-redis: {{ .Values.secret.vault_injector.secrets.redis.templateValue }}
 {{- end }}
@@ -267,7 +267,7 @@ vault.hashicorp.com/agent-inject-secret-command-redis: {{ .Values.secret.vault_i
 {{- end }}
 {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
 vault.hashicorp.com/agent-inject-secret-redissentinel: {{ .Values.secret.vault_injector.secrets.redis_sentinel.path }}
-vault.hashicorp.com/agent-inject-file-redissentinel: REDIS_SENTINEL_PASSWORD
+vault.hashicorp.com/agent-inject-file-redissentinel: {{ include "authelia.secret.path" (merge (dict "Secret" "redis-sentinel") .) }}
 {{- if .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-redissentinel {{ .Values.secret.vault_injector.secrets.redis_sentinel.templateValue }}
 {{- end }}
@@ -278,7 +278,7 @@ vault.hashicorp.com/agent-inject-secret-command-redissentinel: {{ .Values.secret
 {{- end }}
 {{- if and .Values.configMap.notifier.smtp.enabled .Values.configMap.notifier.smtp.enabledSecret }}
 vault.hashicorp.com/agent-inject-secret-smtp: {{ .Values.secret.vault_injector.secrets.smtp.path }}
-vault.hashicorp.com/agent-inject-file-smtp: SMTP_PASSWORD
+vault.hashicorp.com/agent-inject-file-smtp: {{ include "authelia.secret.path" (merge (dict "Secret" "smtp") .) }}
 {{- if .Values.secret.vault_injector.secrets.smtp.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-smtp: {{ .Values.secret.vault_injector.secrets.smtp.templateValue }}
 {{- end }}
@@ -288,7 +288,7 @@ vault.hashicorp.com/agent-inject-secret-command-smtp: {{ .Values.secret.vault_in
 {{- end }}
 {{- if include "authelia.configured.duo" . }}
 vault.hashicorp.com/agent-inject-secret-duo: {{ .Values.secret.vault_injector.secrets.duo.path }}
-vault.hashicorp.com/agent-inject-file-duo: DUO_API_KEY
+vault.hashicorp.com/agent-inject-file-duo: {{ include "authelia.secret.path" (merge (dict "Secret" "duo") .) }}
 {{- if .Values.secret.vault_injector.secrets.duo.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-duo: {{ .Values.secret.vault_injector.secrets.duo.templateValue }}
 {{- end }}
@@ -298,7 +298,7 @@ vault.hashicorp.com/agent-inject-secret-command-duo: {{ .Values.secret.vault_inj
 {{- end }}
 {{- if .Values.configMap.identity_providers.oidc.enabled }}
 vault.hashicorp.com/agent-inject-secret-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.path }}
-vault.hashicorp.com/agent-inject-file-oidc-private-key: OIDC_PRIVATE_KEY
+vault.hashicorp.com/agent-inject-file-oidc-private-key: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-private-key") .) }}
 {{- if .Values.secret.vault_injector.secrets.oidcPrivateKey.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.templateValue }}
 {{- end }}
@@ -306,7 +306,7 @@ vault.hashicorp.com/agent-inject-secret-template-oidc-private-key: {{ .Values.se
 vault.hashicorp.com/agent-inject-secret-command-oidc-private-key: {{ .Values.secret.vault_injector.secrets.oidcPrivateKey.command }}
 {{- end }}
 vault.hashicorp.com/agent-inject-secret-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.path }}
-vault.hashicorp.com/agent-inject-file-oidc-hmac-secret: OIDC_HMAC_SECRET
+vault.hashicorp.com/agent-inject-file-oidc-hmac-secret: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-hmac-secret") .) }}
 {{- if .Values.secret.vault_injector.secrets.oidcHMACSecret.templateValue }}
 vault.hashicorp.com/agent-inject-secret-template-oidc-hmac-secret: {{ .Values.secret.vault_injector.secrets.oidcHMACSecret.templateValue }}
 {{- end }}
@@ -330,6 +330,43 @@ Returns the value of .SecretValue or a randomly generated one
     {{- else -}}
         {{- randAlphaNum 128 | b64enc -}}
     {{- end -}}
+{{- end -}}
+
+{{/*
+Returns the mountPath of the secrets.
+*/}}
+{{- define "authelia.secret.mountPath" -}}
+    {{- default "/config/secrets" .Values.secret.mountPath -}}
+{{- end -}}
+
+{{- define "authelia.secret.path" -}}
+    {{- if eq .Secret "jwt" -}}
+        {{- default "JWT_TOKEN" .Values.secret.jwt.filename -}}
+    {{- else if eq .Secret "storage" -}}
+        {{- default "STORAGE_PASSWORD" .Values.secret.storage.filename -}}
+    {{- else if eq .Secret "session" -}}
+        {{- default "SESSION_ENCRYPTION_KEY" .Values.secret.session.filename -}}
+    {{- else if eq .Secret "ldap" -}}
+        {{- default "LDAP_PASSWORD" .Values.secret.ldap.filename -}}
+    {{- else if eq .Secret "smtp" -}}
+        {{- default "SMTP_PASSWORD" .Values.secret.smtp.filename -}}
+    {{- else if eq .Secret "duo" -}}
+        {{- default "DUO_API_KEY" .Values.secret.duo.filename -}}
+    {{- else if eq .Secret "redis" -}}
+        {{- default "REDIS_PASSWORD" .Values.secret.redis.filename -}}
+    {{- else if eq .Secret "redis-sentinel" -}}
+        {{- default "REDIS_SENTINEL_PASSWORD" .Values.secret.redis_sentinel.filename -}}
+    {{- else if eq .Secret "oidc-private-key" -}}
+        {{- default "OIDC_PRIVATE_KEY" .Values.secret.oidcPrivateKey.filename -}}
+    {{- else if eq .Secret "oidc-hmac-secret" -}}
+        {{- default "OIDC_HMAC_SECRET" .Values.secret.oidcHMACSecret.filename -}}
+    {{- end -}}
+{{- end -}}
+
+{{- define "authelia.secret.fullPath" -}}
+    {{- $path := (include "authelia.secret.mountPath" .) -}}
+    {{- $filename := (include "authelia.secret.path" .) -}}
+    {{- printf "%s/%s" $path $filename -}}
 {{- end -}}
 
 {{/*

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -146,6 +146,11 @@ data:
         tls: {{ toYaml $notifier.smtp.tls | nindent 10 }}
     {{- end }}
     {{- end }}
-    access_control: {{ toYaml .Values.configMap.access_control | nindent 6 }}
+    {{- if .Values.configMap.identity_providers.oidc.enabled }}
+    identity_providers:
+      oidc:
+        clients: {{ toYaml .Values.configMap.identity_providers.oidc.clients | nindent 8 }}
     {{- end }}
+    access_control: {{ toYaml .Values.configMap.access_control | nindent 6 }}
     ...
+    {{- end }}

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -24,44 +24,127 @@ data:
       issuer: {{ default .Values.domain .Values.configMap.totp.issuer }}
       period: {{ default 30 .Values.configMap.totp.period }}
       skew: {{ default 1 .Values.configMap.totp.skew }}
-    {{- with $duoApi := .Values.configMap.duo_api }}
-    duo_api: {{ toYaml $duoApi | nindent 6 }}
+    {{- if include "authelia.configured.duo" . }}
+    duo_api:
+      hostname: {{ .Values.configMap.duo_api.hostname }}
+      integration_key: {{ .Values.configMap.duo_api.integration_key }}
     {{- end }}
+    {{- with $auth := .Values.configMap.authentication_backend }}
     authentication_backend:
-      disable_reset_password: {{ .Values.configMap.authentication_backend.disable_reset_password }}
-    {{- with $file := .Values.configMap.authentication_backend.file }}
-      file: {{ toYaml $file | nindent 8 }}
+      disable_reset_password: {{ $auth.disable_reset_password }}
+    {{- if $auth.file.enabled }}
+      file:
+        path: {{ $auth.file.path }}
+        password: {{ toYaml $auth.file.password | nindent 10 }}
     {{- end }}
-    {{- with $ldap := .Values.configMap.authentication_backend.ldap }}
-      ldap: {{ toYaml $ldap | nindent 8 }}
+    {{- if $auth.ldap.enabled }}
+      ldap:
+        implementation: {{ default "custom" $auth.ldap.implementation }}
+        url: {{ $auth.ldap.url }}
+        start_tls: {{ $auth.ldap.start_tls }}
+        tls: {{ toYaml $auth.ldap.tls | nindent 10 }}
+    {{- if $auth.ldap.base_dn }}
+        base_dn: {{ $auth.ldap.base_dn }}
     {{- end }}
+    {{- if $auth.ldap.username_attribute }}
+        username_attribute: {{ $auth.ldap.username_attribute }}
+    {{- end }}
+    {{- if $auth.ldap.additional_users_dn }}
+        additional_users_dn: {{ $auth.ldap.additional_users_dn }}
+    {{- end }}
+    {{- if $auth.ldap.users_filter }}
+        users_filter: {{ $auth.ldap.users_filter }}
+    {{- end }}
+    {{- if $auth.ldap.additional_groups_dn }}
+        additional_groups_dn: {{ $auth.ldap.additional_groups_dn }}
+    {{- end }}
+    {{- if $auth.ldap.groups_filter }}
+        groups_filter: {{ $auth.ldap.groups_filter }}
+    {{- end }}
+    {{- if $auth.ldap.group_name_attribute }}
+        group_name_attribute: {{ $auth.ldap.group_name_attribute }}
+    {{- end }}
+    {{- end }}
+    {{- if $auth.ldap.mail_attribute }}
+        group_name_attribute: {{ $auth.ldap.mail_attribute }}
+    {{- end }}
+    {{- if $auth.ldap.display_name_attribute }}
+        group_name_attribute: {{ $auth.ldap.display_name_attribute }}
+    {{- end }}
+        user: {{ $auth.ldap.user }}
+    {{- end }}
+    {{- with $session := .Values.configMap.session }}
     session:
-      name: {{ default "authelia_session" .Values.configMap.session.name }}
-      domain: {{ required "A valid .Values.domain entry required!" .Values.domain }}
-      expiration: {{ default "1M" .Values.configMap.session.expiration }}
-      inactivity: {{ default "5m" .Values.configMap.session.inactivity }}
-      remember_me_duration: {{ default "1M" .Values.configMap.session.remember_me_duration }}
-    {{- with $redis := .Values.configMap.session.redis }}
-      redis: {{ toYaml $redis | nindent 8 }}
+      name: {{ default "authelia_session" $session.name }}
+      domain: {{ required "A valid .Values.domain entry required!" $.Values.domain }}
+      expiration: {{ default "1M" $session.expiration }}
+      inactivity: {{ default "5m" $session.inactivity }}
+      remember_me_duration: {{ default "1M" $session.remember_me_duration }}
+    {{- if $session.redis.enabled }}
+      redis:
+        host: {{ $session.redis.host }}
+        port: {{ default 6379 $session.redis.port }}
+        username: {{ default "authelia" $session.redis.username }}
+        maximum_active_connections: {{ default 8 $session.redis.maximum_active_connections }}
+        minimum_idle_connections: {{ default 0 $session.redis.minimum_idle_connections }}
+    {{- if $session.redis.tls.enabled }}
+        tls:
+          server_name: {{ $session.redis.tls.server_name }}
+          skip_verify: {{ $session.redis.tls.skip_verify }}
+          minimum_version: {{ default "TLS1.2" $session.redis.tls.minimum_version }}
+    {{- end }}
+    {{- if $session.redis.high_availability.enabled }}
+        high_availability:
+          sentinel_name: {{ $session.redis.high_availability.sentinel_name }}
+          nodes: {{ toYaml $session.redis.high_availability.nodes | nindent 10 }}
+          route_by_latency: {{ $session.redis.high_availability.route_by_latency }}
+          route_randomly: {{ $session.redis.high_availability.route_randomly }}
+    {{- end }}
+    {{- end }}
     {{- end }}
     regulation: {{ toYaml .Values.configMap.regulation | nindent 6 }}
     storage:
-    {{- with $local := .Values.configMap.storage.local }}
-      local: {{ toYaml $local | nindent 8 }}
+    {{- with $storage := .Values.configMap.storage }}
+    {{- if $storage.local.enabled }}
+      local:
+        path: {{ $storage.local.path }}
     {{- end }}
-    {{- with $mysql := .Values.configMap.storage.mysql }}
-      mysql: {{ toYaml $mysql | nindent 8 }}
+    {{- if $storage.mysql.enabled }}
+      mysql:
+        host: {{ $storage.mysql.host }}
+        port: {{ default 3306 $storage.mysql.port }}
+        database: {{ default "authelia" $storage.mysql.database }}
+        username: {{ default "authelia" $storage.mysql.username }}
     {{- end }}
-    {{- with $postgres := .Values.configMap.storage.postgres }}
-      postgres: {{ toYaml $postgres | nindent 8 }}
+    {{- if $storage.postgres.enabled }}
+      postgres:
+        host: {{ $storage.postgres.host }}
+        port: {{ default 5432 $storage.postgres.port }}
+        database: {{ default "authelia" $storage.postgres.database }}
+        username: {{ default "authelia" $storage.postgres.username }}
+        sslmode: {{ default "disable" $storage.postgres.sslmode }}
     {{- end }}
+    {{- end }}
+    {{- with $notifier := .Values.configMap.notifier }}
     notifier:
       disable_startup_check: {{ $.Values.configMap.notifier.disable_startup_check }}
-    {{- with $filesystem := .Values.configMap.notifier.filesystem }}
-      filesystem: {{ toYaml $filesystem | nindent 8 }}
+    {{- if $notifier.filesystem.enabled }}
+      filesystem:
+        filename: {{ $notifier.filesystem.filename }}
     {{- end }}
-    {{- with $smtp := .Values.configMap.notifier.smtp }}
-      smtp: {{ toYaml $smtp | nindent 8 }}
+    {{- if $notifier.smtp.enabled }}
+      smtp:
+        username: {{ $notifier.smtp.username }}
+        host: {{ $notifier.smtp.host }}
+        port: {{ default 25 $notifier.smtp.port }}
+        sender: {{ $notifier.smtp.sender }}
+        identifier: {{ $notifier.smtp.identifier }}
+        subject: {{ $notifier.smtp.subject }}
+        startup_check_address: {{ $notifier.smtp.startup_check_address }}
+        disable_require_tls: {{ $notifier.smtp.disable_require_tls }}
+        disable_html_emails: {{ $notifier.smtp.disable_html_emails }}
+        tls: {{ toYaml $notifier.smtp.tls | nindent 10 }}
+    {{- end }}
     {{- end }}
     access_control: {{ toYaml .Values.configMap.access_control | nindent 6 }}
     {{- end }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -119,6 +119,12 @@ spec:
           {{- if and (include "authelia.configured.duo" .) (or (include "authelia.configured.duoSecret" .) (hasKey .Values.secret "existingSecret")) }}
         - name: AUTHELIA_DUO_API_SECRET_KEY_FILE
           value: /config/secrets/DUO_API_KEY
+          {{- end }}
+          {{- if .Values.configMap.identity_providers.oidc.enabled }}
+        - name: AUTHELIA_IDENTITY_PROVIDERS_OIDC_HMAC_SECRET_FILE
+          value: /config/secrets/OIDC_HMAC_SECRET
+        - name: AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_PRIVATE_KEY_FILE
+          value: /config/secrets/OIDC_PRIVATE_KEY
         {{- end }}
         {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 12 }}{{- end }}
         {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "startup" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.startup) .) }}
@@ -216,6 +222,12 @@ spec:
             {{- if .Values.configMap.duo_api }}
           - key: {{ default "DUO_API_KEY" .Values.secret.duo.key }}
             path: DUO_API_KEY
+            {{- end }}
+            {{- if .Values.configMap.identity_providers.oidc.enabled }}
+          - key: {{ default "OIDC_PRIVATE_KEY" .Values.secret.oidcPrivateKey.key }}
+            path: /config/secrets/OIDC_PRIVATE_KEY
+          - key: {{ default "OIDC_HMAC_SECRET" .Values.secret.oidcHMACSecret.key }}
+            path: /config/secrets/OIDC_HMAC_SECRET
         {{- end }}
         {{- end }}
         {{- if (include "authelia.enabled.certificatesSecret" .) }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -89,42 +89,42 @@ spec:
         {{- end }}
         env:
         - name: AUTHELIA_JWT_SECRET_FILE
-          value: /config/secrets/JWT_TOKEN
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "jwt") .) }}
         - name: AUTHELIA_SESSION_SECRET_FILE
-          value: /config/secrets/SESSION_ENCRYPTION_KEY
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "session") .) }}
           {{- if .Values.configMap.authentication_backend.ldap.enabled }}
         - name: AUTHELIA_AUTHENTICATION_BACKEND_LDAP_PASSWORD_FILE
-          value: /config/secrets/LDAP_PASSWORD
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "ldap") .) }}
           {{- end }}
           {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
         - name: AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
-          value: /config/secrets/SMTP_PASSWORD
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "smtp") .) }}
           {{- end }}
           {{- if .Values.configMap.storage.postgres.enabled }}
         - name: AUTHELIA_STORAGE_POSTGRES_PASSWORD_FILE
-          value: /config/secrets/STORAGE_PASSWORD
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "storage") .) }}
           {{- end }}
           {{- if .Values.configMap.storage.mysql.enabled }}
         - name: AUTHELIA_STORAGE_MYSQL_PASSWORD_FILE
-          value: /config/secrets/STORAGE_PASSWORD
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "storage") .) }}
           {{- end }}
           {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
         - name: AUTHELIA_SESSION_REDIS_PASSWORD_FILE
-          value: /config/secrets/REDIS_PASSWORD
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "redis") .) }}
           {{- end }}
           {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
         - name: AUTHELIA_SESSION_REDIS_HIGH_AVAILABILITY_SENTINEL_PASSWORD_FILE
-          value: /config/secrets/REDIS_SENTINEL_PASSWORD
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "redis-sentinel") .) }}
           {{- end }}
           {{- if and (include "authelia.configured.duo" .) (or (include "authelia.configured.duoSecret" .) (hasKey .Values.secret "existingSecret")) }}
         - name: AUTHELIA_DUO_API_SECRET_KEY_FILE
-          value: /config/secrets/DUO_API_KEY
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "duo") .) }}
           {{- end }}
           {{- if .Values.configMap.identity_providers.oidc.enabled }}
         - name: AUTHELIA_IDENTITY_PROVIDERS_OIDC_HMAC_SECRET_FILE
-          value: /config/secrets/OIDC_HMAC_SECRET
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "oidc-hmac-secret") .) }}
         - name: AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_PRIVATE_KEY_FILE
-          value: /config/secrets/OIDC_PRIVATE_KEY
+          value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "oidc-private-key") .) }}
         {{- end }}
         {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 12 }}{{- end }}
         {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "startup" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.startup) .) }}
@@ -161,7 +161,7 @@ spec:
           readOnly: false
           {{- end }}
           {{- if not (include "authelia.enabled.injector" .) }}
-        - mountPath: /config/secrets
+        - mountPath: {{ include "authelia.secret.mountPath" . }}
           name: secrets
           readOnly: true
           {{- end }}
@@ -196,38 +196,38 @@ spec:
           secretName: {{ default (include "authelia.name" .) .Values.secret.existingSecret }}
           items:
           - key: {{ default "JWT_TOKEN" .Values.secret.jwt.key }}
-            path: JWT_TOKEN
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "jwt") .) }}
           - key: {{ default "SESSION_ENCRYPTION_KEY" .Values.secret.session.key }}
-            path: SESSION_ENCRYPTION_KEY
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "session") .) }}
             {{- if or .Values.configMap.storage.postgres .Values.configMap.storage.mysql }}
           - key: {{ default "STORAGE_PASSWORD" .Values.secret.storage.key }}
-            path: STORAGE_PASSWORD
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "storage") .) }}
             {{- end }}
             {{- if .Values.configMap.authentication_backend.ldap }}
           - key: {{ default "LDAP_PASSWORD" .Values.secret.ldap.key }}
-            path: LDAP_PASSWORD
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "ldap") .) }}
             {{- end }}
             {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
           - key: {{ default "SMTP_PASSWORD" .Values.secret.smtp.key }}
-            path: SMTP_PASSWORD
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "smtp") .) }}
             {{- end }}
             {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
           - key: {{ default "REDIS_PASSWORD" .Values.secret.redis.key }}
-            path: REDIS_PASSWORD
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "redis") .) }}
             {{- end }}
             {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
           - key: {{ default "REDIS_SENTINEL_PASSWORD" .Values.secret.redis_sentinel.key }}
-            path: REDIS_SENTINEL_PASSWORD
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "redis-sentinel") .) }}
             {{- end }}
             {{- if .Values.configMap.duo_api }}
           - key: {{ default "DUO_API_KEY" .Values.secret.duo.key }}
-            path: DUO_API_KEY
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "duo") .) }}
             {{- end }}
             {{- if .Values.configMap.identity_providers.oidc.enabled }}
           - key: {{ default "OIDC_PRIVATE_KEY" .Values.secret.oidcPrivateKey.key }}
-            path: /config/secrets/OIDC_PRIVATE_KEY
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-private-key") .) }}
           - key: {{ default "OIDC_HMAC_SECRET" .Values.secret.oidcHMACSecret.key }}
-            path: /config/secrets/OIDC_HMAC_SECRET
+            path: {{ include "authelia.secret.path" (merge (dict "Secret" "oidc-hmac-secret") .) }}
         {{- end }}
         {{- end }}
         {{- if (include "authelia.enabled.certificatesSecret" .) }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
     metadata:
       labels: {{ include "authelia.labels" (merge (dict "Labels" .Values.pod.labels) .) | nindent 8 }}
       {{- $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.pod.annotations) .) -}}
-      {{- if or $annotations .Values.secret.vault_injector.enabled }}
+      {{- if or $annotations .Values.secret.vaultInjector.enabled }}
       annotations:
     {{- if $annotations }}{{- $annotations | nindent 8 }}{{- end }}
     {{- include "authelia.annotations.injector" . | nindent 8 }}
@@ -216,7 +216,7 @@ spec:
             path: {{ include "authelia.secret.path" (merge (dict "Secret" "redis") .) }}
             {{- end }}
             {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
-          - key: {{ default "REDIS_SENTINEL_PASSWORD" .Values.secret.redis_sentinel.key }}
+          - key: {{ default "REDIS_SENTINEL_PASSWORD" .Values.secret.redisSentinel.key }}
             path: {{ include "authelia.secret.path" (merge (dict "Secret" "redis-sentinel") .) }}
             {{- end }}
             {{- if .Values.configMap.duo_api }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -89,36 +89,36 @@ spec:
         {{- end }}
         env:
         - name: AUTHELIA_JWT_SECRET_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "JWT_TOKEN") .) }}
+          value: /config/secrets/JWT_TOKEN
         - name: AUTHELIA_SESSION_SECRET_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "SESSION_ENCRYPTION_KEY") .) }}
+          value: /config/secrets/SESSION_ENCRYPTION_KEY
           {{- if .Values.configMap.authentication_backend.ldap.enabled }}
         - name: AUTHELIA_AUTHENTICATION_BACKEND_LDAP_PASSWORD_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "LDAP_PASSWORD") .) }}
+          value: /config/secrets/LDAP_PASSWORD
           {{- end }}
           {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
         - name: AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "SMTP_PASSWORD") .) }}
+          value: /config/secrets/SMTP_PASSWORD
           {{- end }}
           {{- if .Values.configMap.storage.postgres.enabled }}
         - name: AUTHELIA_STORAGE_POSTGRES_PASSWORD_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "STORAGE_PASSWORD") .) }}
+          value: /config/secrets/STORAGE_PASSWORD
           {{- end }}
           {{- if .Values.configMap.storage.mysql.enabled }}
         - name: AUTHELIA_STORAGE_MYSQL_PASSWORD_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "STORAGE_PASSWORD") .) }}
+          value: /config/secrets/STORAGE_PASSWORD
           {{- end }}
           {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
         - name: AUTHELIA_SESSION_REDIS_PASSWORD_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "REDIS_PASSWORD") .) }}
+          value: /config/secrets/REDIS_PASSWORD
           {{- end }}
           {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
         - name: AUTHELIA_SESSION_REDIS_HIGH_AVAILABILITY_SENTINEL_PASSWORD_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "REDIS_SENTINEL_PASSWORD") .) }}
+          value: /config/secrets/REDIS_SENTINEL_PASSWORD
           {{- end }}
           {{- if and (include "authelia.configured.duo" .) (or (include "authelia.configured.duoSecret" .) (hasKey .Values.secret "existingSecret")) }}
         - name: AUTHELIA_DUO_API_SECRET_KEY_FILE
-          value: {{ include "authelia.secret.path" (merge (dict "Name" "DUO_API_KEY") .) }}
+          value: /config/secrets/DUO_API_KEY
         {{- end }}
         {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 12 }}{{- end }}
         {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "startup" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.startup) .) }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -44,8 +44,11 @@ spec:
   template:
     metadata:
       labels: {{ include "authelia.labels" (merge (dict "Labels" .Values.pod.labels) .) | nindent 8 }}
-      {{- with $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.pod.podAnnotations) .) }}
-      annotations: {{ $annotations | nindent 8 }}
+      {{- $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.pod.annotations) .) -}}
+      {{- if or $annotations .Values.secret.vault_injector.enabled }}
+      annotations:
+    {{- if $annotations }}{{- $annotations | nindent 8 }}{{- end }}
+    {{- include "authelia.annotations.injector" . | nindent 8 }}
     {{- end }}
     spec:
       {{- with $tolerations := .Values.pod.tolerations }}
@@ -66,92 +69,100 @@ spec:
       {{- with $context := .Values.pod.securityContext.container }}
       securityContext: {{ toYaml $context | nindent 8 }}
       {{- end }}
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: {{ default (include "authelia.name" .) .Values.rbac.serviceAccountName }}
+      {{- end }}
       containers:
-        - name: authelia
-          image: {{ include "authelia.image" . }}
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
-          {{- with $pullSecrets := .Values.image.pullSecrets }}
-          imagePullSecrets:
-            {{- range $k, $secretName := $pullSecrets }}
-            - name: {{ $secretName }}
+      - name: authelia
+        image: {{ include "authelia.image" . }}
+        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        {{- with $pullSecrets := .Values.image.pullSecrets }}
+        imagePullSecrets: {{- range $k, $secretName := $pullSecrets }}
+        - name: {{ $secretName }}
+        {{- end }}
+        {{- end }}
+        command: ["authelia"]
+        args:
+        - --config=/config/configuration.yaml
+        {{- with $resources :=.Values.pod.resources }}
+        resources: {{ toYaml $resources | nindent 10 }}
+        {{- end }}
+        env:
+        - name: AUTHELIA_JWT_SECRET_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "JWT_TOKEN") .) }}
+        - name: AUTHELIA_SESSION_SECRET_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "SESSION_ENCRYPTION_KEY") .) }}
+          {{- if .Values.configMap.authentication_backend.ldap.enabled }}
+        - name: AUTHELIA_AUTHENTICATION_BACKEND_LDAP_PASSWORD_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "LDAP_PASSWORD") .) }}
+          {{- end }}
+          {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
+        - name: AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "SMTP_PASSWORD") .) }}
+          {{- end }}
+          {{- if .Values.configMap.storage.postgres.enabled }}
+        - name: AUTHELIA_STORAGE_POSTGRES_PASSWORD_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "STORAGE_PASSWORD") .) }}
+          {{- end }}
+          {{- if .Values.configMap.storage.mysql.enabled }}
+        - name: AUTHELIA_STORAGE_MYSQL_PASSWORD_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "STORAGE_PASSWORD") .) }}
+          {{- end }}
+          {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
+        - name: AUTHELIA_SESSION_REDIS_PASSWORD_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "REDIS_PASSWORD") .) }}
+          {{- end }}
+          {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
+        - name: AUTHELIA_SESSION_REDIS_HIGH_AVAILABILITY_SENTINEL_PASSWORD_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "REDIS_SENTINEL_PASSWORD") .) }}
+          {{- end }}
+          {{- if and (include "authelia.configured.duo" .) (or (include "authelia.configured.duoSecret" .) (hasKey .Values.secret "existingSecret")) }}
+        - name: AUTHELIA_DUO_API_SECRET_KEY_FILE
+          value: {{ include "authelia.secret.path" (merge (dict "Name" "DUO_API_KEY") .) }}
+        {{- end }}
+        {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 12 }}{{- end }}
+        {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "startup" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.startup) .) }}
+        {{- $probe | nindent 8 }}
+        {{- end }}
+        {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "liveness" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.liveness) .) }}
+        {{- $probe | nindent 8 }}
+        {{- end }}
+        {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "readiness" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.readiness) .) }}
+        {{- $probe | nindent 8 }}
+        {{- end }}
+        ports:
+        - name: http
+          containerPort: {{ default 9091  .Values.configMap.port }}
+          protocol: TCP
+        volumeMounts:
+          {{- if (include "authelia.enabled.persistentVolumeClaim" .) }}
+        - mountPath: /config
+          name: authelia
+          readOnly: {{ .Values.persistence.readOnly }}
+          {{- with $subPath := .Values.persistence.subPath }}
+          subPath: {{ $subPath }}
+          {{- end }}
+          {{- with $subPathExpr := .Values.persistence.subPathExpr }}
+          subPathExpr: {{ $subPathExpr }}
+            {{- end }}
+            {{- with $mountPropagation := .Values.persistence.mountPropagation }}
+            mountPropagation: {{ $mountPropagation }}
           {{- end }}
           {{- end }}
-          command: [ "authelia" ]
-          args:
-            - --config=/config/configuration.yaml
-          {{- with $resources :=.Values.pod.resources }}
-          resources: {{ toYaml $resources | nindent 12 }}
+          {{- if (include "authelia.enabled.configMap" .) }}
+        - mountPath: /config
+          name: config
+          readOnly: false
           {{- end }}
-          env:
-            - name: AUTHELIA_JWT_SECRET_FILE
-              value: /config/secrets/JWT_TOKEN
-            - name: AUTHELIA_SESSION_SECRET_FILE
-              value: /config/secrets/SESSION_ENCRYPTION_KEY
-            {{- if .Values.configMap.authentication_backend.ldap }}
-            - name: AUTHELIA_AUTHENTICATION_BACKEND_LDAP_PASSWORD_FILE
-              value: /config/secrets/LDAP_PASSWORD
-            {{- end }}
-            {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
-            - name: AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
-              value: /config/secrets/SMTP_PASSWORD
-            {{- end }}
-            {{- if .Values.configMap.storage.postgres }}
-            - name: AUTHELIA_STORAGE_POSTGRES_PASSWORD_FILE
-              value: /config/secrets/STORAGE_PASSWORD
-            {{- end }}
-            {{- if .Values.configMap.storage.mysql }}
-            - name: AUTHELIA_STORAGE_MYSQL_PASSWORD_FILE
-              value: /config/secrets/STORAGE_PASSWORD
-            {{- end }}
-            {{- if and (include "authelia.configured.redisSecret" .) (include "authelia.configured.redis" .) }}
-            - name: AUTHELIA_SESSION_REDIS_PASSWORD_FILE
-              value: /config/secrets/REDIS_PASSWORD
-            {{- end }}
-            {{- if and (include "authelia.configured.duo" .) (or (include "authelia.configured.duoSecret" .) (hasKey .Values.secret "existingSecret")) }}
-            - name: AUTHELIA_DUO_API_SECRET_KEY_FILE
-              value: /config/secrets/DUO_API_KEY
+          {{- if not (include "authelia.enabled.injector" .) }}
+        - mountPath: /config/secrets
+          name: secrets
+          readOnly: true
           {{- end }}
-          {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 12 }}{{- end }}
-          ports:
-            - name: http
-              containerPort: {{ default 9091  .Values.configMap.port }}
-              protocol: TCP
-          {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "startup" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.startup) .) }}
-          {{- $probe | nindent 10 }}
-          {{- end }}
-          {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "liveness" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.liveness) .) }}
-          {{- $probe | nindent 10 }}
-          {{- end }}
-          {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "readiness" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.readiness) .) }}
-          {{- $probe | nindent 10 }}
-          {{- end }}
-          volumeMounts:
-            {{- if (include "authelia.enabled.persistentVolumeClaim" .) }}
-            - mountPath: /config
-              name: authelia
-              readOnly: {{ .Values.persistence.readOnly }}
-              {{- with $subPath := .Values.persistence.subPath }}
-              subPath: {{ $subPath }}
-              {{- end }}
-              {{- with $subPathExpr := .Values.persistence.subPathExpr }}
-              subPathExpr: {{ $subPathExpr }}
-              {{- end }}
-              {{- with $mountPropagation := .Values.persistence.mountPropagation }}
-              mountPropagation: {{ $mountPropagation }}
-            {{- end }}
-            {{- end }}
-            {{- if (include "authelia.enabled.configMap" .) }}
-            - mountPath: /config
-              name: config
-              readOnly: false
-            {{- end }}
-            - mountPath: /config/secrets
-              name: secrets
-              readOnly: true
-            {{- if (include "authelia.enabled.certificatesSecret" .) }}
-            - mountPath: /config/certificates
-              name: certificates
-              readOnly: true
+          {{- if (include "authelia.enabled.certificatesSecret" .) }}
+        - mountPath: /config/certificates
+          name: certificates
+          readOnly: true
           {{- end }}
           {{- with $mounts := .Values.pod.extraVolumeMounts }}
           {{ toYaml $mounts | indent 12 }}
@@ -161,50 +172,56 @@ spec:
       {{- end }}
       volumes:
         {{- if (include "authelia.enabled.persistentVolumeClaim" .) }}
-        - name: authelia
-          persistentVolumeClaim:
-            claimName: {{ default (include "authelia.name" .) .Values.persistence.existingClaim }}
+      - name: authelia
+        persistentVolumeClaim:
+          claimName: {{ default (include "authelia.name" .) .Values.persistence.existingClaim }}
         {{- end }}
         {{- if (include "authelia.enabled.configMap" .) }}
-        - name: config
-          configMap:
-            name: {{ default (include "authelia.name" .) .Values.configMap.existingConfigMap }}
-            items:
-              - key: {{ default "configuration.yaml" .Values.configMap.key }}
-                path: configuration.yaml
+      - name: config
+        configMap:
+          name: {{ default (include "authelia.name" .) .Values.configMap.existingConfigMap }}
+          items:
+          - key: {{ default "configuration.yaml" .Values.configMap.key }}
+            path: configuration.yaml
         {{- end }}
-        - name: secrets
-          secret:
-            secretName: {{ default (include "authelia.name" .) .Values.secret.existingSecret }}
-            items:
-              - key: {{ default "JWT_TOKEN" .Values.secret.jwt.key }}
-                path: JWT_TOKEN
-              - key: {{ default "SESSION_ENCRYPTION_KEY" .Values.secret.session.key }}
-                path: SESSION_ENCRYPTION_KEY
-              {{- if or .Values.configMap.storage.postgres .Values.configMap.storage.mysql }}
-              - key: {{ default "STORAGE_PASSWORD" .Values.secret.storage.key }}
-                path: STORAGE_PASSWORD
-              {{- end }}
-              {{- if .Values.configMap.authentication_backend.ldap }}
-              - key: {{ default "LDAP_PASSWORD" .Values.secret.ldap.key }}
-                path: LDAP_PASSWORD
-              {{- end }}
-              {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
-              - key: {{ default "SMTP_PASSWORD" .Values.secret.smtp.key }}
-                path: SMTP_PASSWORD
-              {{- end }}
-              {{- if and (include "authelia.configured.redisSecret" .) (include "authelia.configured.redis" .) }}
-              - key: {{ default "REDIS_PASSWORD" .Values.secret.redis.key }}
-                path: REDIS_PASSWORD
-              {{- end }}
-              {{- if .Values.configMap.duo_api }}
-              - key: {{ default "DUO_API_KEY" .Values.secret.duo.key }}
-                path: DUO_API_KEY
+        {{- if not (include "authelia.enabled.injector" .) }}
+      - name: secrets
+        secret:
+          secretName: {{ default (include "authelia.name" .) .Values.secret.existingSecret }}
+          items:
+          - key: {{ default "JWT_TOKEN" .Values.secret.jwt.key }}
+            path: JWT_TOKEN
+          - key: {{ default "SESSION_ENCRYPTION_KEY" .Values.secret.session.key }}
+            path: SESSION_ENCRYPTION_KEY
+            {{- if or .Values.configMap.storage.postgres .Values.configMap.storage.mysql }}
+          - key: {{ default "STORAGE_PASSWORD" .Values.secret.storage.key }}
+            path: STORAGE_PASSWORD
+            {{- end }}
+            {{- if .Values.configMap.authentication_backend.ldap }}
+          - key: {{ default "LDAP_PASSWORD" .Values.secret.ldap.key }}
+            path: LDAP_PASSWORD
+            {{- end }}
+            {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
+          - key: {{ default "SMTP_PASSWORD" .Values.secret.smtp.key }}
+            path: SMTP_PASSWORD
+            {{- end }}
+            {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
+          - key: {{ default "REDIS_PASSWORD" .Values.secret.redis.key }}
+            path: REDIS_PASSWORD
+            {{- end }}
+            {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
+          - key: {{ default "REDIS_SENTINEL_PASSWORD" .Values.secret.redis_sentinel.key }}
+            path: REDIS_SENTINEL_PASSWORD
+            {{- end }}
+            {{- if .Values.configMap.duo_api }}
+          - key: {{ default "DUO_API_KEY" .Values.secret.duo.key }}
+            path: DUO_API_KEY
+        {{- end }}
         {{- end }}
         {{- if (include "authelia.enabled.certificatesSecret" .) }}
-        - name: certificates
-          secret:
-            secretName: {{ include "authelia.names.certificatesSecret" . }}
+      - name: certificates
+        secret:
+          secretName: {{ include "authelia.names.certificatesSecret" . }}
   {{- end }}
   {{- with .Values.pod.extraVolumes }}
   {{ toYaml . | indent 6 }}

--- a/charts/authelia/templates/rbac/serviceAccount.yaml
+++ b/charts/authelia/templates/rbac/serviceAccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.rbac.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "authelia.name" .) .Values.rbac.serviceAccountName }}
+  labels: {{ include "authelia.labels" (merge (dict "Labels" .Values.rbac.labels) .) | nindent 4 }}
+  {{- with $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.rbac.annotations) .) }}
+  annotations: {{ $annotations | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -21,7 +21,7 @@ data:
     {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
     {{- .Values.secret.redis.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.redis.value) .) }}
     {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
-    {{- .Values.secret.redis_sentinel.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.redis_sentinel.value) .) }}
+    {{- .Values.secret.redisSentinel.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.redisSentinel.value) .) }}
     {{- end }}
     {{- end }}
     {{- if or (include "authelia.configured.smtp" .) .Values.configMap.notifier.smtp.enabledSecret }}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -12,16 +12,19 @@ metadata:
 data:
   {{- .Values.secret.jwt.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.jwt.value) .) }}
     {{- .Values.secret.session.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.session.value) .) }}
-    {{- if or .Values.configMap.storage.postgres .Values.configMap.storage.mysql }}
+    {{- if or .Values.configMap.storage.postgres.enabled .Values.configMap.storage.mysql.enabled }}
     {{- .Values.secret.storage.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.storage.value) .) }}
     {{- end }}
     {{- if .Values.configMap.authentication_backend.ldap }}
     {{- .Values.secret.ldap.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.ldap.value) .) }}
     {{- end }}
-    {{- if and (include "authelia.configured.redis" .) (include "authelia.configured.redisSecret" .) }}
+    {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
     {{- .Values.secret.redis.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.redis.value) .) }}
+    {{- if and .Values.configMap.session.redis.high_availability.enabled .Values.configMap.session.redis.high_availability.enabledSecret }}
+    {{- .Values.secret.redis_sentinel.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.redis_sentinel.value) .) }}
     {{- end }}
-    {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
+    {{- end }}
+    {{- if or (include "authelia.configured.smtp" .) .Values.configMap.notifier.smtp.enabledSecret }}
     {{- .Values.secret.smtp.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.smtp.value) .) }}
     {{- end }}
     {{- if or (include "authelia.configured.duo" .) (include "authelia.configured.duoSecret" .) }}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -29,5 +29,9 @@ data:
     {{- end }}
     {{- if or (include "authelia.configured.duo" .) (include "authelia.configured.duoSecret" .) }}
     {{- .Values.secret.duo.key | nindent 2 }}: {{ .Values.secret.duo.value | b64enc }}
+    {{- end }}
+    {{- if .Values.configMap.identity_providers.oidc.enabled }}
+    {{- .Values.secret.oidcHMACSecret.key | nindent 2}}: {{ .Values.secret.oidcHMACSecret.value | b64enc }}
+    {{- .Values.secret.oidcPrivateKey.key | nindent 2}}: {{ .Values.secret.oidcPrivateKey.value | b64enc }}
   {{- end }}
 {{- end -}}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.27.3
+  tag: 4.27.4
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -959,7 +959,7 @@ secret:
     key: REDIS_PASSWORD
     # value:
     filename: REDIS_PASSWORD
-  redis_sentinel:
+  redisSentinel:
     key: REDIS_SENTINEL_PASSWORD
     # value:
     filename: REDIS_SENTINEL_PASSWORD
@@ -977,7 +977,7 @@ secret:
     filename: OIDC_HMAC_SECRET
 
   ## HashiCorp Vault Injector configuration.
-  vault_injector:
+  vaultInjector:
 
     ## Enable the vault injector annotations. This will disable secret injection via other means.
     ## To see the annotations and what they do see: https://www.vaultproject.io/docs/platform/k8s/injector/annotations
@@ -1087,7 +1087,7 @@ secret:
         ## Vault after render command specific to redis.
         ## Annotation: vault.hashicorp.com/agent-inject-template-redis
         command: ""
-      redis_sentinel:
+      redisSentinel:
         ## Vault Path to the Authelia redis sentinel secret.
         ## Annotation: vault.hashicorp.com/agent-inject-secret-redis-sentinel
         path: secrets/authelia/redis-sentinel

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -1,6 +1,6 @@
 ---
 ## @formatter:off
-## values.lite.yaml
+## values.local.yaml
 ##
 ## Repository: authelia https://charts.authelia.com
 ## Chart: authelia
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.27.2
+  tag: 4.27.3
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:
@@ -38,6 +38,20 @@ extraAnnotations: {}
 extraLabels: {}
 # extraLabels:
 #   myLabel: myValue
+
+##
+## RBAC Configuration.
+##
+rbac:
+
+  ## Enable RBAC. Turning this on associates Authelia with a service account.
+  enabled: false
+
+  annotations: {}
+  labels: {}
+
+  serviceAccountName: authelia
+
 
 ## Authelia Domain
 ## Should be the root domain you want to protect.
@@ -94,8 +108,8 @@ ingress:
 
     # matchOverride: Host(`auth.example.com`) && PathPrefix(`/`)
 
-    entrypoints: []
-    # entrypoints:
+    entryPoints: []
+    # entryPoints:
     # - http
 
     # priority: 10
@@ -414,29 +428,28 @@ configMap:
   ## TOTP Configuration
   ##
   ## Parameters used for TOTP generation
-  totp: {}
-  # totp:
+  totp:
     ## The issuer name displayed in the Authenticator application of your choice
     ## See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format for more info on issuer names
     ## Defaults to <domain>.
-    # issuer: authelia.com
+    issuer: ""
     ## The period in seconds a one-time password is current for. Changing this will require all users to register
     ## their TOTP applications again. Warning: before changing period read the docs link below.
-    # period: 30
+    period: 30
     ## The skew controls number of one-time passwords either side of the current one that are valid.
     ## Warning: before changing skew read the docs link below.
     ## See: https://www.authelia.com/docs/configuration/one-time-password.html#period-and-skew to read the documentation.
-    # skew: 1
+    skew: 1
 
   ##
   ## Duo Push API Configuration
   ##
   ## Parameters used to contact the Duo API. Those are generated when you protect an application of type
   ## "Partner Auth API" in the management panel.
-  duo_api: {}
-  # duo_api:
-  #   hostname: api-123456789.example.com
-  #   integration_key: ABCDEF
+  duo_api:
+    enabled: false
+    hostname: api-123456789.example.com
+    integration_key: ABCDEF
 
   ##
   ## Authentication Backend Provider Configuration
@@ -462,8 +475,11 @@ configMap:
     ## This backend allows Authelia to be scaled to more
     ## than one instance and therefore is recommended for
     ## production.
-    ldap: {}
-    # ldap:
+    ldap:
+
+      ## Enable LDAP Backend.
+      enabled: false
+
       ## The LDAP implementation, this affects elements like the attribute utilised for resetting a password.
       ## Acceptable options are as follows:
       ## - 'activedirectory' - For Microsoft Active Directory.
@@ -473,29 +489,29 @@ configMap:
       ## Depending on the option here certain other values in this section have a default value, notably all of the
       ## attribute mappings have a default value that this config overrides, you can read more about these default values
       ## at https://www.authelia.com/docs/configuration/authentication/ldap.html#defaults
-      # implementation: custom
+      implementation: activedirectory
 
       ## The url to the ldap server. Format: <scheme>://<address>[:<port>].
       ## Scheme can be ldap or ldaps in the format (port optional).
-      # url: ldap://openldap.default.svc.cluster.local
+      url: ldap://openldap.default.svc.cluster.local
 
       ## Use StartTLS with the LDAP connection.
-      # start_tls: false
+      start_tls: false
 
-      # tls:
+      tls:
         ## Server Name for certificate validation (in case it's not set correctly in the URL).
-        # server_name: ldap.example.com
+        server_name: ""
 
         ## Skip verifying the server certificate (to allow a self-signed certificate).
         ## In preference to setting this we strongly recommend you add the public portion of the certificate to the
         ## certificates directory which is defined by the `certificates_directory` option at the top of the config.
-        # skip_verify: false
+        skip_verify: false
 
         ## Minimum TLS version for either Secure LDAP or LDAP StartTLS.
-        # minimum_version: TLS1.2
+        minimum_version: TLS1.2
 
       ## The base dn for every LDAP query.
-      # base_dn: DC=example,DC=com
+      base_dn: DC=example,DC=com
 
       ## The attribute holding the username of the user. This attribute is used to populate the username in the session
       ## information. It was introduced due to #561 to handle case insensitive search queries. For you information,
@@ -505,10 +521,10 @@ configMap:
       ## otherwise it would break the configuration for that user. Technically, non-unique attributes like 'mail' can also
       ## be used but we don't recommend using them, we instead advise to use the attributes mentioned above
       ## (sAMAccountName and uid) to follow https://www.ietf.org/rfc/rfc2307.txt.
-      # username_attribute: uid
+      username_attribute: ""
 
       ## An additional dn to define the scope to all users.
-      # additional_users_dn: OU=Users
+      additional_users_dn: OU=Users
 
       ## The users filter used in search queries to find the user profile based on input filled in login form.
       ## Various placeholders are available in the user filter:
@@ -526,10 +542,10 @@ configMap:
       ##
       ## To allow sign in both with username and email, one can use a filter like
       ## (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person))
-      # users_filter: (&({username_attribute}={input})(objectClass=person))
+      users_filter: ""
 
       ## An additional dn to define the scope of groups.
-      # additional_groups_dn: OU=Groups
+      additional_groups_dn: OU=Groups
 
       ## The groups filter used in search queries to find the groups of the user.
       ## - {input} is a placeholder replaced by what the user inputs in the login form.
@@ -544,20 +560,20 @@ configMap:
       ##
       ## If your groups use the `groupOfUniqueNames` structure use this instead:
       ##    (&(uniquemember={dn})(objectclass=groupOfUniqueNames))
-      # groups_filter: (&(member={dn})(objectclass=groupOfNames))
+      groups_filter: ""
 
       ## The attribute holding the name of the group
-      # group_name_attribute: cn
+      group_name_attribute: ""
 
       ## The attribute holding the mail address of the user. If multiple email addresses are defined for a user, only the
       ## first one returned by the LDAP server is used.
-      # mail_attribute: mail
+      mail_attribute: ""
 
       ## The attribute holding the display name of the user. This will be used to greet an authenticated user.
-      # display_name_attribute: displayname
+      display_name_attribute: ""
 
       ## The username of the admin user.
-      # user: CN=Authelia,DC=example,DC=com
+      user: CN=Authelia,DC=example,DC=com
 
     ##
     ## File (Authentication Provider)
@@ -572,12 +588,15 @@ configMap:
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
     file:
+      enabled: true
       path: /config/users_database.yml
       password:
         algorithm: sha512
         iterations: 100000
         key_length: 32
         salt_length: 16
+        memory: 1024
+        parallelism: 8
 
   ##
   ## Access Control Configuration
@@ -611,77 +630,60 @@ configMap:
     ## resource if there is no policy to be applied to the user.
     default_policy: deny
 
-    networks:
-      - name: internal
-        networks:
-          - 10.10.0.0/16
-          - 192.168.2.0/24
-      - name: VPN
-        networks: 10.9.0.0/16
+    networks: []
+    # networks:
+    # - name: private
+    #   networks:
+    #   - 10.0.0.0/8
+    #   - 172.16.0.0/12
+    #   - 192.168.0.0/16
+    # - name: vpn
+    #   networks:
+    #   - 10.9.0.0/16
 
-    rules:
-      ## Rules applied to everyone
-      - domain: public.example.com
-        policy: bypass
-
-      - domain: secure.example.com
-        policy: one_factor
-        ## Network based rule, if not provided any network matches.
-        networks:
-          - internal
-          - VPN
-          - 192.168.1.0/24
-          - 10.0.0.1
-
-      - domain:
-          - secure.example.com
-          - private.example.com
-        policy: two_factor
-
-      - domain: singlefactor.example.com
-        policy: one_factor
-
-      ## Rules applied to 'admins' group
-      - domain: "mx2.mail.example.com"
-        subject: "group:admins"
-        policy: deny
-
-      - domain: "*.example.com"
-        subject:
-          - "group:admins"
-          - "group:moderators"
-        policy: two_factor
-
-      ## Rules applied to 'dev' group
-      - domain: dev.example.com
-        resources:
-          - "^/groups/dev/.*$"
-        subject: "group:dev"
-        policy: two_factor
-
-      ## Rules applied to user 'john'
-      - domain: dev.example.com
-        resources:
-          - "^/users/john/.*$"
-        subject: "user:john"
-        policy: two_factor
-
-      ## Rules applied to user 'harry'
-      - domain: dev.example.com
-        resources:
-          - "^/users/harry/.*$"
-        subject: "user:harry"
-        policy: two_factor
-
-      ## Rules applied to user 'bob'
-      - domain: "*.mail.example.com"
-        subject: "user:bob"
-        policy: two_factor
-      - domain: "dev.example.com"
-        resources:
-          - "^/users/bob/.*$"
-        subject: "user:bob"
-        policy: two_factor
+    rules: []
+    # rules:
+    # - domain: public.example.com
+    #   policy: bypass
+    # - domain: "*.example.com"
+    #   policy: bypass
+    #   methods:
+    #   - OPTIONS
+    # - domain: secure.example.com
+    #   policy: one_factor
+    #   networks:
+    #   - private
+    #   - vpn
+    #   - 192.168.1.0/24
+    #   - 10.0.0.1
+    # - domain:
+    #   - secure.example.com
+    #   - private.example.com
+    #   policy: two_factor
+    # - domain: singlefactor.example.com
+    #   policy: one_factor
+    # - domain: "mx2.mail.example.com"
+    #   subject: "group:admins"
+    #   policy: deny
+    # - domain: "*.example.com"
+    #   subject:
+    #   - "group:admins"
+    #   - "group:moderators"
+    #   policy: two_factor
+    # - domain: dev.example.com
+    #   resources:
+    #   - "^/groups/dev/.*$"
+    #   subject: "group:dev"
+    #   policy: two_factor
+    # - domain: dev.example.com
+    #   resources:
+    #   - "^/users/john/.*$"
+    #   subject:
+    #   - ["group:dev", "user:john"]
+    #   - "group:admins"
+    #   policy: two_factor
+    # - domain: "{user}.example.com"
+    #   policy: bypass
 
   ##
   ## Session Provider Configuration
@@ -711,53 +713,51 @@ configMap:
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
     ## The redis connection details
-    redis: {}
-    # redis:
-      # host: redis.databases.svc.cluster.local
-      # port: 6379
+    redis:
+      enabled: false
+      enabledSecret: false
+      host: redis.databases.svc.cluster.local
+      port: 6379
 
       ## Optional username to be used with authentication.
-      # username: authelia
-
-      ## Password can also be set using a secret: https://docs.authelia.com/configuration/secrets.html
-      # password: authelia
+      username: authelia
 
       ## This is the Redis DB Index https://redis.io/commands/select (sometimes referred to as database number, DB, etc).
-      # database_index: 0
+      database_index: 0
 
       ## The maximum number of concurrent active connections to Redis.
-      # maximum_active_connections: 8
+      maximum_active_connections: 8
 
       ## The target number of idle connections to have open ready for work. Useful when opening connections is slow.
-      # minimum_idle_connections: 0
+      minimum_idle_connections: 0
 
       ## The Redis TLS configuration. If defined will require a TLS connection to the Redis instance(s).
-      # tls:
+      tls:
+        enabled: false
 
         ## Server Name for certificate validation (in case you are using the IP or non-FQDN in the host option).
-        # server_name: myredis.example.com
+        server_name: ""
 
         ## Skip verifying the server certificate (to allow a self-signed certificate).
         ## In preference to setting this we strongly recommend you add the public portion of the certificate to the
         ## certificates directory which is defined by the `certificates_directory` option at the top of the config.
-        # skip_verify: false
+        skip_verify: false
 
         ## Minimum TLS version for the connection.
-        # minimum_version: TLS1.2
+        minimum_version: TLS1.2
 
       ## The Redis HA configuration options.
       ## This provides specific options to Redis Sentinel, sentinel_name must be defined (Master Name).
-      # high_availability:
-
+      high_availability:
+        enabled: false
+        enabledSecret: false
         ## Sentinel Name / Master Name
-        # sentinel_name: mysentinel
-
-        ## Specific password for Redis Sentinel. The node username and password is configured above.
-        # sentinel_password: sentinel_specific_pass
+        sentinel_name: mysentinel
 
         ## The additional nodes to pre-seed the redis provider with (for sentinel).
         ## If the host in the above section is defined, it will be combined with this list to connect to sentinel.
         ## For high availability to be used you must have either defined; the host above or at least one node below.
+        nodes: []
         # nodes:
         #   - host: sentinel-0.databases.svc.cluster.local
         #     port: 26379
@@ -765,10 +765,10 @@ configMap:
         #     port: 26379
 
         ## Choose the host with the lowest latency.
-        # route_by_latency: false
+        route_by_latency: false
 
         ## Choose the host randomly.
-        # route_randomly: false
+        route_randomly: false
 
   ##
   ## Regulation Configuration
@@ -803,6 +803,7 @@ configMap:
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
     local:
+      enabled: true
       path: /config/db.sqlite3
 
     ##
@@ -810,21 +811,23 @@ configMap:
     ##
     ## Also supports MariaDB
     ##
-    # mysql:
-      # host: mysql.databases.svc.cluster.local
-      # port: 3306
-      # database: authelia
-      # username: authelia
+    mysql:
+      enabled: false
+      host: mysql.databases.svc.cluster.local
+      port: 3306
+      database: authelia
+      username: authelia
 
     ##
     ## PostgreSQL (Storage Provider)
     ##
-    # postgres:
-    #   host: 127.0.0.1
-    #   port: 5432
-    #   database: authelia
-    #   username: authelia
-    #   sslmode: disable
+    postgres:
+      enabled: false
+      host: 127.0.0.1
+      port: 5432
+      database: authelia
+      username: authelia
+      sslmode: disable
 
   ##
   ## Notification Provider
@@ -842,6 +845,7 @@ configMap:
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
     filesystem:
+      enabled: true
       filename: /config/notification.txt
 
     ##
@@ -854,33 +858,61 @@ configMap:
     ##        (only works for unauthenticated connections)
     ##   - validate the SMTP server x509 certificate during the TLS handshake against the hosts trusted certificates
     ##     (configure in tls section)
-    # smtp:
-      # username: test
-      # host: smtp.mail.svc.cluster.local
-      # port: 25
-      # sender: admin@example.com
+    smtp:
+      enabled: false
+      enabledSecret: false
+      username: test
+      host: smtp.mail.svc.cluster.local
+      port: 25
+      sender: admin@example.com
       ## HELO/EHLO Identifier. Some SMTP Servers may reject the default of localhost.
-      # identifier: localhost
+      identifier: localhost
       ## Subject configuration of the emails sent.
       ## {title} is replaced by the text from the notifier
-      # subject: "[Authelia] {title}"
+      subject: "[Authelia] {title}"
       ## This address is used during the startup check to verify the email configuration is correct.
       ## It's not important what it is except if your email server only allows local delivery.
-      # startup_check_address: test@authelia.com
-      # disable_require_tls: false
-      # disable_html_emails: false
+      startup_check_address: test@authelia.com
+      disable_require_tls: false
+      disable_html_emails: false
 
-      # tls:
+      tls:
         ## Server Name for certificate validation (in case you are using the IP or non-FQDN in the host option).
-        # server_name: smtp.example.com
+        server_name: ""
 
         ## Skip verifying the server certificate (to allow a self-signed certificate).
         ## In preference to setting this we strongly recommend you add the public portion of the certificate to the
         ## certificates directory which is defined by the `certificates_directory` option at the top of the config.
-        # skip_verify: false
+        skip_verify: false
 
         ## Minimum TLS version for either StartTLS or SMTPS.
-        # minimum_version: TLS1.2
+        minimum_version: TLS1.2
+
+  identity_providers:
+    oidc:
+      ## Enables this in the config map. Currently in alpha stage there is no official build supporting OIDC.
+      ## This exists for testing and preparation.
+      enabled: false
+      clients:
+      - id: myapp
+        description: My Application
+        ## Secret shared between client and OP. Must be bcrypt hashed.
+        secret: $2y$12$Bk1mw11OwVlG0uYWVJaoEuDkbL62FpEUsq59CXzPbe5oL61zR4XoG
+        ## Policy is either one_factor or two_factor.
+        policy: two_factor
+        ## List of valid redirect URIs
+        redirect_uris:
+        - https://oidc.example.com/oauth2/callback
+        scopes:
+        - openid
+        - profile
+        - email
+        - groups
+        grant_types:
+        - refresh_token
+        - authorization_code
+        response_types:
+        - code
 
 ##
 ## Authelia Secret Generator.
@@ -900,27 +932,209 @@ secret:
   # labels:
   #   myLabel: myValue
 
+  mountPath: /config/secrets
+
+  ## Secrets.
   jwt:
     key: JWT_TOKEN
     # value:
+    filename: JWT_TOKEN
   ldap:
     key: LDAP_PASSWORD
     # value:
+    filename: LDAP_PASSWORD
   storage:
     key: STORAGE_PASSWORD
     # value:
+    filename: STORAGE_PASSWORD
   session:
     key: SESSION_ENCRYPTION_KEY
     # value:
+    filename: SESSION_ENCRYPTION_KEY
   duo:
     key: DUO_API_KEY
     # value:
+    filename: DUO_API_KEY
   redis:
     key: REDIS_PASSWORD
     # value:
+    filename: REDIS_PASSWORD
+  redis_sentinel:
+    key: REDIS_SENTINEL_PASSWORD
+    # value:
+    filename: REDIS_SENTINEL_PASSWORD
   smtp:
     key: SMTP_PASSWORD
     # value:
+    filename: SMTP_PASSWORD
+  oidcPrivateKey:
+    key: OIDC_PRIVATE_KEY
+    # value:
+    filename: OIDC_PRIVATE_KEY
+  oidcHMACSecret:
+    key: OIDC_HMAC_SECRET
+    # value:
+    filename: OIDC_HMAC_SECRET
+
+  ## HashiCorp Vault Injector configuration.
+  vault_injector:
+
+    ## Enable the vault injector annotations. This will disable secret injection via other means.
+    ## To see the annotations and what they do see: https://www.vaultproject.io/docs/platform/k8s/injector/annotations
+    ## Annotations with a blank string do not get configured at all.
+    ## Additional annotations can be configured via the secret.annotations: {} above.
+    ## Secrets are by default rendered in the /config/secrets directory. Changing this can be done via editing the
+    ## secret.mountPath value. You can alter the filenames with the secret.<secretName>.filename values.
+    enabled: false
+
+    ## The vault role to assign via annotations.
+    ## Annotation: vault.hashicorp.com/role
+    role: authelia
+
+    agent:
+      ## Annotation: vault.hashicorp.com/agent-inject-status
+      status: update
+
+      ## Annotation: vault.hashicorp.com/agent-configmap
+      configMap: ""
+
+      ## Annotation: vault.hashicorp.com/agent-image
+      image: ""
+
+      ## Annotation: vault.hashicorp.com/agent-init-first
+      initFirst: "false"
+
+      ## Annotation: vault.hashicorp.com/agent-inject-command
+      command: "sh -c 'kill HUP $(pidof authelia)'"
+
+      ## Annotation: vault.hashicorp.com/agent-run-as-same-user
+      runAsSameUser: "true"
+
+      ## If defined, sets the default template for all secrets. Can be overriden by individual templates in secrets.
+      ## Annotation: vault.hashicorp.com/agent-inject-template-*
+      templateValue: ""
+
+    secrets:
+      jwt:
+        ## Vault Path to the Authelia JWT secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-jwt
+        path: secrets/authelia/jwt
+
+        ## Vault template specific to JWT.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-jwt
+        templateValue: ""
+
+        ## Vault after render command specific to JWT.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-jwt
+        command: ""
+      ldap:
+        ## Vault Path to the Authelia LDAP secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-ldap
+        path: secrets/authelia/ldap
+
+        ## Vault template specific to LDAP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-ldap
+        templateValue: ""
+
+        ## Vault after render command specific to LDAP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-ldap
+        command: ""
+      storage:
+        ## Vault Path to the Authelia storage secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-storage
+        path: secrets/authelia/storage
+
+        ## Vault template specific to storage.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-storage
+        templateValue: ""
+
+        ## Vault after render command specific to storage.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-storage
+        command: ""
+      session:
+        ## Vault Path to the Authelia session secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-session
+        path: secrets/authelia/session
+
+        ## Vault template specific to session.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-session
+        templateValue: ""
+
+        ## Vault after render command specific to session.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-session
+        command: ""
+      duo:
+        ## Vault Path to the Authelia duo secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-duo
+        path: secrets/authelia/duo
+
+        ## Vault template specific to duo.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-duo
+        templateValue: ""
+
+        ## Vault after render command specific to duo.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-duo
+        command: ""
+      redis:
+        ## Vault Path to the Authelia redis secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-redis
+        path: secrets/authelia/redis
+
+        ## Vault template specific to redis.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis
+        templateValue: ""
+
+        ## Vault after render command specific to redis.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis
+        command: ""
+      redis_sentinel:
+        ## Vault Path to the Authelia redis sentinel secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-redis-sentinel
+        path: secrets/authelia/redis-sentinel
+
+        ## Vault template specific to redis sentinel.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis-sentinel
+        templateValue: ""
+
+        ## Vault after render command specific to redis sentinel.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis-sentinel
+        command: ""
+      smtp:
+        ## Vault Path to the Authelia SMTP secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-smtp
+        path: secrets/authelia/smtp
+
+        ## Vault template specific to SMTP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-smtp
+        templateValue: ""
+
+        ## Vault after render command specific to SMTP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-smtp
+        command: ""
+      oidcPrivateKey:
+        ## Vault Path to the Authelia OIDC private key secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-oidc-private-key
+        path: secrets/authelia/oidc-private-key
+
+        ## Vault template specific to OIDC private key.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-private-key
+        templateValue: ""
+
+        ## Vault after render command specific to OIDC private key.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-private-key
+        command: ""
+      oidcHMACSecret:
+        ## Vault Path to the Authelia OIDC HMAC secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-oidc-hmac-secret
+        path: secrets/authelia/oidc-private-key
+
+        ## Vault template specific to OIDC HMAC secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-hmac-secret
+        templateValue: ""
+
+        ## Vault after render command specific to OIDC HMAC secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-hmac-secret
+        command: ""
 
 certificates:
   # existingSecret: authelia

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -17,7 +17,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.27.2
+  tag: 4.27.3
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:
@@ -37,6 +37,20 @@ extraAnnotations: {}
 extraLabels: {}
 # extraLabels:
 #   myLabel: myValue
+
+##
+## RBAC Configuration.
+##
+rbac:
+  
+  ## Enable RBAC. Turning this on associates Authelia with a service account.
+  enabled: true
+  
+  annotations: {}
+  labels: {}
+  
+  serviceAccountName: authelia
+
 
 ## Authelia Domain
 ## Should be the root domain you want to protect.
@@ -413,29 +427,28 @@ configMap:
   ## TOTP Configuration
   ##
   ## Parameters used for TOTP generation
-  totp: {}
-  # totp:
+  totp:
     ## The issuer name displayed in the Authenticator application of your choice
     ## See: https://github.com/google/google-authenticator/wiki/Key-Uri-Format for more info on issuer names
     ## Defaults to <domain>.
-    # issuer: authelia.com
+    issuer: ""
     ## The period in seconds a one-time password is current for. Changing this will require all users to register
     ## their TOTP applications again. Warning: before changing period read the docs link below.
-    # period: 30
+    period: 30
     ## The skew controls number of one-time passwords either side of the current one that are valid.
     ## Warning: before changing skew read the docs link below.
     ## See: https://www.authelia.com/docs/configuration/one-time-password.html#period-and-skew to read the documentation.
-    # skew: 1
+    skew: 1
 
   ##
   ## Duo Push API Configuration
   ##
   ## Parameters used to contact the Duo API. Those are generated when you protect an application of type
   ## "Partner Auth API" in the management panel.
-  duo_api: {}
-  # duo_api:
-  #   hostname: api-123456789.example.com
-  #   integration_key: ABCDEF
+  duo_api:
+    enabled: false
+    hostname: api-123456789.example.com
+    integration_key: ABCDEF
 
   ##
   ## Authentication Backend Provider Configuration
@@ -461,7 +474,11 @@ configMap:
     ## This backend allows Authelia to be scaled to more
     ## than one instance and therefore is recommended for
     ## production.
-    # ldap:
+    ldap:
+      
+      ## Enable LDAP Backend.
+      enabled: true
+      
       ## The LDAP implementation, this affects elements like the attribute utilised for resetting a password.
       ## Acceptable options are as follows:
       ## - 'activedirectory' - For Microsoft Active Directory.
@@ -471,29 +488,29 @@ configMap:
       ## Depending on the option here certain other values in this section have a default value, notably all of the
       ## attribute mappings have a default value that this config overrides, you can read more about these default values
       ## at https://www.authelia.com/docs/configuration/authentication/ldap.html#defaults
-      # implementation: custom
+      implementation: activedirectory
 
       ## The url to the ldap server. Format: <scheme>://<address>[:<port>].
       ## Scheme can be ldap or ldaps in the format (port optional).
-      # url: ldap://openldap.default.svc.cluster.local
+      url: ldap://openldap.default.svc.cluster.local
 
       ## Use StartTLS with the LDAP connection.
-      # start_tls: false
+      start_tls: false
 
-      # tls:
+      tls:
         ## Server Name for certificate validation (in case it's not set correctly in the URL).
-        # server_name: ldap.example.com
+        server_name: ""
 
         ## Skip verifying the server certificate (to allow a self-signed certificate).
         ## In preference to setting this we strongly recommend you add the public portion of the certificate to the
         ## certificates directory which is defined by the `certificates_directory` option at the top of the config.
-        # skip_verify: false
+        skip_verify: false
 
         ## Minimum TLS version for either Secure LDAP or LDAP StartTLS.
-        # minimum_version: TLS1.2
+        minimum_version: TLS1.2
 
       ## The base dn for every LDAP query.
-      # base_dn: DC=example,DC=com
+      base_dn: DC=example,DC=com
 
       ## The attribute holding the username of the user. This attribute is used to populate the username in the session
       ## information. It was introduced due to #561 to handle case insensitive search queries. For you information,
@@ -503,10 +520,10 @@ configMap:
       ## otherwise it would break the configuration for that user. Technically, non-unique attributes like 'mail' can also
       ## be used but we don't recommend using them, we instead advise to use the attributes mentioned above
       ## (sAMAccountName and uid) to follow https://www.ietf.org/rfc/rfc2307.txt.
-      # username_attribute: uid
+      username_attribute: ""
 
       ## An additional dn to define the scope to all users.
-      # additional_users_dn: OU=Users
+      additional_users_dn: OU=Users
 
       ## The users filter used in search queries to find the user profile based on input filled in login form.
       ## Various placeholders are available in the user filter:
@@ -524,10 +541,10 @@ configMap:
       ##
       ## To allow sign in both with username and email, one can use a filter like
       ## (&(|({username_attribute}={input})({mail_attribute}={input}))(objectClass=person))
-      # users_filter: (&({username_attribute}={input})(objectClass=person))
+      users_filter: ""
 
       ## An additional dn to define the scope of groups.
-      # additional_groups_dn: OU=Groups
+      additional_groups_dn: OU=Groups
 
       ## The groups filter used in search queries to find the groups of the user.
       ## - {input} is a placeholder replaced by what the user inputs in the login form.
@@ -542,20 +559,20 @@ configMap:
       ##
       ## If your groups use the `groupOfUniqueNames` structure use this instead:
       ##    (&(uniquemember={dn})(objectclass=groupOfUniqueNames))
-      # groups_filter: (&(member={dn})(objectclass=groupOfNames))
+      groups_filter: ""
 
       ## The attribute holding the name of the group
-      # group_name_attribute: cn
+      group_name_attribute: ""
 
       ## The attribute holding the mail address of the user. If multiple email addresses are defined for a user, only the
       ## first one returned by the LDAP server is used.
-      # mail_attribute: mail
+      mail_attribute: ""
 
       ## The attribute holding the display name of the user. This will be used to greet an authenticated user.
-      # display_name_attribute: displayname
+      display_name_attribute: ""
 
       ## The username of the admin user.
-      # user: CN=Authelia,DC=example,DC=com
+      user: CN=Authelia,DC=example,DC=com
 
     ##
     ## File (Authentication Provider)
@@ -569,15 +586,16 @@ configMap:
     ##
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
-    # file:
-    #   path: /config/users_database.yml
-    #   password:
-    #     algorithm: argon2id
-    #     iterations: 1
-    #     key_length: 32
-    #     salt_length: 16
-    #     memory: 1024
-    #     parallelism: 8
+    file:
+      enabled: false
+      path: /config/users_database.yml
+      password:
+        algorithm: argon2id
+        iterations: 1
+        key_length: 32
+        salt_length: 16
+        memory: 1024
+        parallelism: 8
 
   ##
   ## Access Control Configuration
@@ -643,52 +661,51 @@ configMap:
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
     ## The redis connection details
-    # redis:
-      # host: redis.databases.svc.cluster.local
-      # port: 6379
+    redis:
+      enabled: true
+      enabledSecret: false
+      host: redis.databases.svc.cluster.local
+      port: 6379
 
       ## Optional username to be used with authentication.
-      # username: authelia
-
-      ## Password can also be set using a secret: https://docs.authelia.com/configuration/secrets.html
-      # password: authelia
+      username: authelia
 
       ## This is the Redis DB Index https://redis.io/commands/select (sometimes referred to as database number, DB, etc).
-      # database_index: 0
+      database_index: 0
 
       ## The maximum number of concurrent active connections to Redis.
-      # maximum_active_connections: 8
+      maximum_active_connections: 8
 
       ## The target number of idle connections to have open ready for work. Useful when opening connections is slow.
-      # minimum_idle_connections: 0
+      minimum_idle_connections: 0
 
       ## The Redis TLS configuration. If defined will require a TLS connection to the Redis instance(s).
-      # tls:
-
+      tls:
+        enabled: false
+        
         ## Server Name for certificate validation (in case you are using the IP or non-FQDN in the host option).
-        # server_name: myredis.example.com
+        server_name: ""
 
         ## Skip verifying the server certificate (to allow a self-signed certificate).
         ## In preference to setting this we strongly recommend you add the public portion of the certificate to the
         ## certificates directory which is defined by the `certificates_directory` option at the top of the config.
-        # skip_verify: false
+        skip_verify: false
 
         ## Minimum TLS version for the connection.
-        # minimum_version: TLS1.2
+        minimum_version: TLS1.2
 
       ## The Redis HA configuration options.
       ## This provides specific options to Redis Sentinel, sentinel_name must be defined (Master Name).
-      # high_availability:
-
+      high_availability:
+        enabled: false
+        enabledSecret: false
         ## Sentinel Name / Master Name
-        # sentinel_name: mysentinel
-
-        ## Specific password for Redis Sentinel. The node username and password is configured above.
-        # sentinel_password: sentinel_specific_pass
+        sentinel_name: mysentinel
 
         ## The additional nodes to pre-seed the redis provider with (for sentinel).
         ## If the host in the above section is defined, it will be combined with this list to connect to sentinel.
         ## For high availability to be used you must have either defined; the host above or at least one node below.
+        nodes: []
         # nodes:
         #   - host: sentinel-0.databases.svc.cluster.local
         #     port: 26379
@@ -696,10 +713,10 @@ configMap:
         #     port: 26379
 
         ## Choose the host with the lowest latency.
-        # route_by_latency: false
+        route_by_latency: false
 
         ## Choose the host randomly.
-        # route_randomly: false
+        route_randomly: false
 
   ##
   ## Regulation Configuration
@@ -724,8 +741,7 @@ configMap:
   ## Storage Provider Configuration
   ##
   ## The available providers are: `local`, `mysql`, `postgres`. You must use one and only one of these providers.
-  storage: {}
-  # storage:
+  storage:
     ##
     ## Local (Storage Provider)
     ##
@@ -734,29 +750,32 @@ configMap:
     ##
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
-    # local:
-    #   path: /config/db.sqlite3
+    local:
+      enabled: false
+      path: /config/db.sqlite3
 
     ##
     ## MySQL (Storage Provider)
     ##
     ## Also supports MariaDB
     ##
-    # mysql:
-    #   host: mysql.databases.svc.cluster.local
-    #   port: 3306
-    #   database: authelia
-    #   username: authelia
+    mysql:
+      enabled: false
+      host: mysql.databases.svc.cluster.local
+      port: 3306
+      database: authelia
+      username: authelia
 
     ##
     ## PostgreSQL (Storage Provider)
     ##
-    # postgres:
-    #   host: 127.0.0.1
-    #   port: 5432
-    #   database: authelia
-    #   username: authelia
-    #   sslmode: disable
+    postgres:
+      enabled: true
+      host: 127.0.0.1
+      port: 5432
+      database: authelia
+      username: authelia
+      sslmode: disable
 
   ##
   ## Notification Provider
@@ -773,8 +792,9 @@ configMap:
     ##
     ## Important: Kubernetes (or HA) users must read https://www.authelia.com/docs/features/statelessness.html
     ##
-    # filesystem:
-    #   filename: /config/notification.txt
+    filesystem:
+      enabled: false
+      filename: /config/notification.txt
 
     ##
     ## SMTP (Notification Provider)
@@ -786,33 +806,35 @@ configMap:
     ##        (only works for unauthenticated connections)
     ##   - validate the SMTP server x509 certificate during the TLS handshake against the hosts trusted certificates
     ##     (configure in tls section)
-    # smtp:
-      # username: test
-      # host: smtp.mail.svc.cluster.local
-      # port: 25
-      # sender: admin@example.com
+    smtp:
+      enabled: true
+      enabledSecret: false
+      username: test
+      host: smtp.mail.svc.cluster.local
+      port: 25
+      sender: admin@example.com
       ## HELO/EHLO Identifier. Some SMTP Servers may reject the default of localhost.
-      # identifier: localhost
+      identifier: localhost
       ## Subject configuration of the emails sent.
       ## {title} is replaced by the text from the notifier
-      # subject: "[Authelia] {title}"
+      subject: "[Authelia] {title}"
       ## This address is used during the startup check to verify the email configuration is correct.
       ## It's not important what it is except if your email server only allows local delivery.
-      # startup_check_address: test@authelia.com
-      # disable_require_tls: false
-      # disable_html_emails: false
+      startup_check_address: test@authelia.com
+      disable_require_tls: false
+      disable_html_emails: false
 
-      # tls:
+      tls:
         ## Server Name for certificate validation (in case you are using the IP or non-FQDN in the host option).
-        # server_name: smtp.example.com
+        server_name: ""
 
         ## Skip verifying the server certificate (to allow a self-signed certificate).
         ## In preference to setting this we strongly recommend you add the public portion of the certificate to the
         ## certificates directory which is defined by the `certificates_directory` option at the top of the config.
-        # skip_verify: false
+        skip_verify: false
 
         ## Minimum TLS version for either StartTLS or SMTPS.
-        # minimum_version: TLS1.2
+        minimum_version: TLS1.2
 
 ##
 ## Authelia Secret Generator.
@@ -831,7 +853,8 @@ secret:
   labels: {}
   # labels:
   #   myLabel: myValue
-
+  
+  ## Secrets.
   jwt:
     key: JWT_TOKEN
     # value:
@@ -850,9 +873,55 @@ secret:
   redis:
     key: REDIS_PASSWORD
     # value:
+  redis_sentinel:
+    key: REDIS_SENTINEL_PASSWORD
+    # value:
   smtp:
     key: SMTP_PASSWORD
     # value:
+  
+  ## HashiCorp Vault Injector configuration.
+  vault_injector:
+    enabled: true
+    role: authelia
+    sameAsUser: true
+    status: update
+    command: "sh -c 'kill HUP $(pidof authelia)'"
+    templateValue: ""
+    secrets:
+      jwt:
+        path: AUTHELIA_JWT
+        templateValue: ""
+        command: ""
+      ldap:
+        path: AUTHELIA_LDAP_PASSWORD
+        templateValue: ""
+        command: ""
+      storage:
+        path: AUTHELIA_STORAGE_PASSWORD
+        templateValue: ""
+        command: ""
+      session:
+        path: AUTHELIA_SESSION_ENCRYPTION_KEY
+        templateValue: ""
+        command: ""
+      duo:
+        path: AUTHELIA_DUO_API_KEY
+        templateValue: ""
+        command: ""
+      redis:
+        path: AUTHELIA_REDIS_PASSWORD
+        templateValue: ""
+        command: ""
+      redis_sentinel:
+        path: AUTHELIA_REDIS_SENTINEL_PASSWORD
+        templateValue: ""
+        command: ""
+      smtp:
+        path: AUTHELIA_SMTP_PASSWORD
+        templateValue: ""
+        command: ""
+
 
 certificates:
   # existingSecret: authelia

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -17,7 +17,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.27.3
+  tag: 4.27.4
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -835,6 +835,34 @@ configMap:
 
         ## Minimum TLS version for either StartTLS or SMTPS.
         minimum_version: TLS1.2
+  
+  identity_providers:
+    oidc:
+      ## Enables this in the config map. Currently in alpha stage there is no official build supporting OIDC.
+      ## This exists for testing and preparation.
+      enabled: false
+      clients:
+      - id: myapp
+        description: My Application
+        ## Secret shared between client and OP. Must be bcrypt hashed.
+        secret: $2y$12$Bk1mw11OwVlG0uYWVJaoEuDkbL62FpEUsq59CXzPbe5oL61zR4XoG
+        ## Policy is either one_factor or two_factor.
+        policy: two_factor
+        ## List of valid redirect URIs
+        redirect_uris:
+        - https://oidc.example.com/oauth2/callback
+        scopes:
+        - openid
+        - profile
+        - email
+        - groups
+        grant_types:
+        - refresh_token
+        - authorization_code
+        response_types:
+        - code
+        
+
 
 ##
 ## Authelia Secret Generator.
@@ -878,6 +906,12 @@ secret:
     # value:
   smtp:
     key: SMTP_PASSWORD
+    # value:
+  oidcPrivateKey:
+    key: OIDC_PRIVATE_KEY
+    # value:
+  oidcHMACSecret:
+    key: OIDC_HMAC_SECRET
     # value:
 
   ## HashiCorp Vault Injector configuration.
@@ -927,6 +961,15 @@ secret:
         path: AUTHELIA_SMTP_PASSWORD
         templateValue: ""
         command: ""
+      oidcPrivateKey:
+        path: AUTHELIA_OIDC_PRIVATE_KEY
+        templateValue: ""
+        command: ""
+      oidcHMACSecret:
+        path: AUTHELIA_OIDC_HMAC_SECRET
+        templateValue: ""
+        command: ""
+        
 certificates:
   # existingSecret: authelia
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -882,7 +882,7 @@ secret:
   
   ## HashiCorp Vault Injector configuration.
   vault_injector:
-    enabled: true
+    enabled: false
     role: authelia
     sameAsUser: true
     status: update

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -884,10 +884,16 @@ secret:
   vault_injector:
     enabled: false
     role: authelia
-    sameAsUser: true
-    status: update
-    command: "sh -c 'kill HUP $(pidof authelia)'"
-    templateValue: ""
+
+    agent:
+      status: update
+      configMap: ""
+      image: ""
+      initFirst: "false"
+      runAsSameUser: "true"
+      command: "sh -c 'kill HUP $(pidof authelia)'"
+      templateValue: ""
+
     secrets:
       jwt:
         path: AUTHELIA_JWT

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -44,7 +44,7 @@ extraLabels: {}
 rbac:
 
   ## Enable RBAC. Turning this on associates Authelia with a service account.
-  enabled: true
+  enabled: false
 
   annotations: {}
   labels: {}
@@ -630,8 +630,59 @@ configMap:
     default_policy: deny
 
     networks: []
+    # networks:
+    # - name: private
+    #   networks:
+    #   - 10.0.0.0/8
+    #   - 172.16.0.0/12
+    #   - 192.168.0.0/16
+    # - name: vpn
+    #   networks:
+    #   - 10.9.0.0/16
 
     rules: []
+    # rules:
+    # - domain: public.example.com
+    #   policy: bypass
+    # - domain: "*.example.com"
+    #   policy: bypass
+    #   methods:
+    #   - OPTIONS
+    # - domain: secure.example.com
+    #   policy: one_factor
+    #   networks:
+    #   - private
+    #   - vpn
+    #   - 192.168.1.0/24
+    #   - 10.0.0.1
+    # - domain:
+    #   - secure.example.com
+    #   - private.example.com
+    #   policy: two_factor
+    # - domain: singlefactor.example.com
+    #   policy: one_factor
+    # - domain: "mx2.mail.example.com"
+    #   subject: "group:admins"
+    #   policy: deny
+    # - domain: "*.example.com"
+    #   subject:
+    #   - "group:admins"
+    #   - "group:moderators"
+    #   policy: two_factor
+    # - domain: dev.example.com
+    #   resources:
+    #   - "^/groups/dev/.*$"
+    #   subject: "group:dev"
+    #   policy: two_factor
+    # - domain: dev.example.com
+    #   resources:
+    #   - "^/users/john/.*$"
+    #   subject:
+    #   - ["group:dev", "user:john"]
+    #   - "group:admins"
+    #   policy: two_factor
+    # - domain: "{user}.example.com"
+    #   policy: bypass
 
   ##
   ## Session Provider Configuration
@@ -886,98 +937,202 @@ secret:
   jwt:
     key: JWT_TOKEN
     # value:
-    # filename:
+    filename: JWT_TOKEN
   ldap:
     key: LDAP_PASSWORD
     # value:
-    # filename:
+    filename: LDAP_PASSWORD
   storage:
     key: STORAGE_PASSWORD
     # value:
-    # filename:
+    filename: STORAGE_PASSWORD
   session:
     key: SESSION_ENCRYPTION_KEY
     # value:
-    # filename:
+    filename: SESSION_ENCRYPTION_KEY
   duo:
     key: DUO_API_KEY
     # value:
-    # filename:
+    filename: DUO_API_KEY
   redis:
     key: REDIS_PASSWORD
     # value:
-    # filename:
+    filename: REDIS_PASSWORD
   redis_sentinel:
     key: REDIS_SENTINEL_PASSWORD
     # value:
-    # filename:
+    filename: REDIS_SENTINEL_PASSWORD
   smtp:
     key: SMTP_PASSWORD
     # value:
-    # filename:
+    filename: SMTP_PASSWORD
   oidcPrivateKey:
     key: OIDC_PRIVATE_KEY
     # value:
-    # filename:
+    filename: OIDC_PRIVATE_KEY
   oidcHMACSecret:
     key: OIDC_HMAC_SECRET
     # value:
-    # filename:
+    filename: OIDC_HMAC_SECRET
 
   ## HashiCorp Vault Injector configuration.
   vault_injector:
+
+    ## Enable the vault injector annotations. This will disable secret injection via other means.
+    ## To see the annotations and what they do see: https://www.vaultproject.io/docs/platform/k8s/injector/annotations
+    ## Annotations with a blank string do not get configured at all.
+    ## Additional annotations can be configured via the secret.annotations: {} above.
+    ## Secrets are by default rendered in the /config/secrets directory. Changing this can be done via editing the
+    ## secret.mountPath value. You can alter the filenames with the secret.<secretName>.filename values.
     enabled: false
+
+    ## The vault role to assign via annotations.
+    ## Annotation: vault.hashicorp.com/role
     role: authelia
 
     agent:
+      ## Annotation: vault.hashicorp.com/agent-inject-status
       status: update
+
+      ## Annotation: vault.hashicorp.com/agent-configmap
       configMap: ""
+
+      ## Annotation: vault.hashicorp.com/agent-image
       image: ""
+
+      ## Annotation: vault.hashicorp.com/agent-init-first
       initFirst: "false"
-      runAsSameUser: "true"
+
+      ## Annotation: vault.hashicorp.com/agent-inject-command
       command: "sh -c 'kill HUP $(pidof authelia)'"
+
+      ## Annotation: vault.hashicorp.com/agent-run-as-same-user
+      runAsSameUser: "true"
+
+      ## If defined, sets the default template for all secrets. Can be overriden by individual templates in secrets.
+      ## Annotation: vault.hashicorp.com/agent-inject-template-*
       templateValue: ""
 
     secrets:
       jwt:
-        path: AUTHELIA_JWT
+        ## Vault Path to the Authelia JWT secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-jwt
+        path: secrets/authelia/jwt
+
+        ## Vault template specific to JWT.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-jwt
         templateValue: ""
+
+        ## Vault after render command specific to JWT.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-jwt
         command: ""
       ldap:
-        path: AUTHELIA_LDAP_PASSWORD
+        ## Vault Path to the Authelia LDAP secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-ldap
+        path: secrets/authelia/ldap
+
+        ## Vault template specific to LDAP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-ldap
         templateValue: ""
+
+        ## Vault after render command specific to LDAP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-ldap
         command: ""
       storage:
-        path: AUTHELIA_STORAGE_PASSWORD
+        ## Vault Path to the Authelia storage secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-storage
+        path: secrets/authelia/storage
+
+        ## Vault template specific to storage.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-storage
         templateValue: ""
+
+        ## Vault after render command specific to storage.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-storage
         command: ""
       session:
-        path: AUTHELIA_SESSION_ENCRYPTION_KEY
+        ## Vault Path to the Authelia session secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-session
+        path: secrets/authelia/session
+
+        ## Vault template specific to session.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-session
         templateValue: ""
+
+        ## Vault after render command specific to session.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-session
         command: ""
       duo:
-        path: AUTHELIA_DUO_API_KEY
+        ## Vault Path to the Authelia duo secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-duo
+        path: secrets/authelia/duo
+
+        ## Vault template specific to duo.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-duo
         templateValue: ""
+
+        ## Vault after render command specific to duo.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-duo
         command: ""
       redis:
-        path: AUTHELIA_REDIS_PASSWORD
+        ## Vault Path to the Authelia redis secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-redis
+        path: secrets/authelia/redis
+
+        ## Vault template specific to redis.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis
         templateValue: ""
+
+        ## Vault after render command specific to redis.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis
         command: ""
       redis_sentinel:
-        path: AUTHELIA_REDIS_SENTINEL_PASSWORD
+        ## Vault Path to the Authelia redis sentinel secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-redis-sentinel
+        path: secrets/authelia/redis-sentinel
+
+        ## Vault template specific to redis sentinel.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis-sentinel
         templateValue: ""
+
+        ## Vault after render command specific to redis sentinel.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-redis-sentinel
         command: ""
       smtp:
-        path: AUTHELIA_SMTP_PASSWORD
+        ## Vault Path to the Authelia SMTP secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-smtp
+        path: secrets/authelia/smtp
+
+        ## Vault template specific to SMTP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-smtp
         templateValue: ""
+
+        ## Vault after render command specific to SMTP.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-smtp
         command: ""
       oidcPrivateKey:
-        path: AUTHELIA_OIDC_PRIVATE_KEY
+        ## Vault Path to the Authelia OIDC private key secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-oidc-private-key
+        path: secrets/authelia/oidc-private-key
+
+        ## Vault template specific to OIDC private key.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-private-key
         templateValue: ""
+
+        ## Vault after render command specific to OIDC private key.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-private-key
         command: ""
       oidcHMACSecret:
-        path: AUTHELIA_OIDC_HMAC_SECRET
+        ## Vault Path to the Authelia OIDC HMAC secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-secret-oidc-hmac-secret
+        path: secrets/authelia/oidc-private-key
+
+        ## Vault template specific to OIDC HMAC secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-hmac-secret
         templateValue: ""
+
+        ## Vault after render command specific to OIDC HMAC secret.
+        ## Annotation: vault.hashicorp.com/agent-inject-template-oidc-hmac-secret
         command: ""
 
 certificates:

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -835,7 +835,7 @@ configMap:
 
         ## Minimum TLS version for either StartTLS or SMTPS.
         minimum_version: TLS1.2
-  
+
   identity_providers:
     oidc:
       ## Enables this in the config map. Currently in alpha stage there is no official build supporting OIDC.
@@ -861,8 +861,6 @@ configMap:
         - authorization_code
         response_types:
         - code
-        
-
 
 ##
 ## Authelia Secret Generator.
@@ -882,37 +880,49 @@ secret:
   # labels:
   #   myLabel: myValue
 
+  mountPath: /config/secrets
+
   ## Secrets.
   jwt:
     key: JWT_TOKEN
     # value:
+    # filename:
   ldap:
     key: LDAP_PASSWORD
     # value:
+    # filename:
   storage:
     key: STORAGE_PASSWORD
     # value:
+    # filename:
   session:
     key: SESSION_ENCRYPTION_KEY
     # value:
+    # filename:
   duo:
     key: DUO_API_KEY
     # value:
+    # filename:
   redis:
     key: REDIS_PASSWORD
     # value:
+    # filename:
   redis_sentinel:
     key: REDIS_SENTINEL_PASSWORD
     # value:
+    # filename:
   smtp:
     key: SMTP_PASSWORD
     # value:
+    # filename:
   oidcPrivateKey:
     key: OIDC_PRIVATE_KEY
     # value:
+    # filename:
   oidcHMACSecret:
     key: OIDC_HMAC_SECRET
     # value:
+    # filename:
 
   ## HashiCorp Vault Injector configuration.
   vault_injector:
@@ -969,7 +979,7 @@ secret:
         path: AUTHELIA_OIDC_HMAC_SECRET
         templateValue: ""
         command: ""
-        
+
 certificates:
   # existingSecret: authelia
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -42,13 +42,13 @@ extraLabels: {}
 ## RBAC Configuration.
 ##
 rbac:
-  
+
   ## Enable RBAC. Turning this on associates Authelia with a service account.
   enabled: true
-  
+
   annotations: {}
   labels: {}
-  
+
   serviceAccountName: authelia
 
 
@@ -475,10 +475,10 @@ configMap:
     ## than one instance and therefore is recommended for
     ## production.
     ldap:
-      
+
       ## Enable LDAP Backend.
       enabled: true
-      
+
       ## The LDAP implementation, this affects elements like the attribute utilised for resetting a password.
       ## Acceptable options are as follows:
       ## - 'activedirectory' - For Microsoft Active Directory.
@@ -682,7 +682,7 @@ configMap:
       ## The Redis TLS configuration. If defined will require a TLS connection to the Redis instance(s).
       tls:
         enabled: false
-        
+
         ## Server Name for certificate validation (in case you are using the IP or non-FQDN in the host option).
         server_name: ""
 
@@ -853,7 +853,7 @@ secret:
   labels: {}
   # labels:
   #   myLabel: myValue
-  
+
   ## Secrets.
   jwt:
     key: JWT_TOKEN
@@ -879,7 +879,7 @@ secret:
   smtp:
     key: SMTP_PASSWORD
     # value:
-  
+
   ## HashiCorp Vault Injector configuration.
   vault_injector:
     enabled: false
@@ -921,8 +921,6 @@ secret:
         path: AUTHELIA_SMTP_PASSWORD
         templateValue: ""
         command: ""
-
-
 certificates:
   # existingSecret: authelia
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -958,7 +958,7 @@ secret:
     key: REDIS_PASSWORD
     # value:
     filename: REDIS_PASSWORD
-  redis_sentinel:
+  redisSentinel:
     key: REDIS_SENTINEL_PASSWORD
     # value:
     filename: REDIS_SENTINEL_PASSWORD
@@ -976,7 +976,7 @@ secret:
     filename: OIDC_HMAC_SECRET
 
   ## HashiCorp Vault Injector configuration.
-  vault_injector:
+  vaultInjector:
 
     ## Enable the vault injector annotations. This will disable secret injection via other means.
     ## To see the annotations and what they do see: https://www.vaultproject.io/docs/platform/k8s/injector/annotations
@@ -1086,7 +1086,7 @@ secret:
         ## Vault after render command specific to redis.
         ## Annotation: vault.hashicorp.com/agent-inject-template-redis
         command: ""
-      redis_sentinel:
+      redisSentinel:
         ## Vault Path to the Authelia redis sentinel secret.
         ## Annotation: vault.hashicorp.com/agent-inject-secret-redis-sentinel
         path: secrets/authelia/redis-sentinel


### PR DESCRIPTION
This commit adds the HashiCorp Vault injector configuration. Additionally it refactors the ConfigMap and Secret generation methods. It introduces several major changes to the values.yaml which should be considered breaking. Several providers now have an 'enabled' option and some have 'enabledSecret'. How they operate is 'enabled' renders the values of the section in the ConfigMap, and the enabledSecret option forces the secret to be used - this is used for redis and SMTP. Lastly it removes the commented sections of a majority of the commented configuration in values.yaml making it more compatible with various GitOps solutions.

Related to #12