### PR TITLE
ci: refactor pipeline

### DIFF
--- a/.buildkite/ct.version.yaml
+++ b/.buildkite/ct.version.yaml
@@ -1,0 +1,13 @@
+chart-dirs:
+- charts
+chart-repos:
+- authelia=https://charts.authelia.com
+check-version-increment: true
+exclude-deprecated: true
+excluded-charts: []
+remote: origin
+since: HEAD
+target-branch: master
+validate-chart-schema: false
+validate-maintainers: false
+validate-yaml: false

--- a/.buildkite/ct.yaml
+++ b/.buildkite/ct.yaml
@@ -1,8 +1,8 @@
 chart-dirs:
-  - charts
+- charts
 chart-repos:
-  - authelia=https://charts.authelia.com
-check-version-increment: true
+- authelia=https://charts.authelia.com
+check-version-increment: false
 chart-yaml-schema: .buildkite/chart_schema.yaml
 exclude-deprecated: true
 excluded-charts: []

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,5 @@
 env:
-  CR_BYPASS: ${CR_BYPASS}
-  CT_BYPASS: ${CT_BYPASS}
+  CHART_CHANGES: ${CHART_CHANGES}
 
 steps:
 - command: "ct --config .buildkite/ct.version.yaml lint"
@@ -29,7 +28,7 @@ steps:
   - ".cr-release-packages/*"
   agents:
     charts: "true"
-  if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+  if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
 - commands:
   - "mkdir .cr-release-packages"
@@ -41,7 +40,7 @@ steps:
     charts: "true"
   depends_on:
   - step: "package"
-  if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+  if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
 - commands:
   - "mkdir .cr-release-packages .cr-index"
@@ -54,4 +53,4 @@ steps:
     charts: "true"
   depends_on:
   - step: "upload"
-  if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+  if: build.branch == "master" && build.env("CHART_CHANGES") == "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,37 +1,52 @@
 env:
   CR_BYPASS: ${CR_BYPASS}
+  CT_BYPASS: ${CT_BYPASS}
 
 steps:
-  - label: ":helm: Linting (Chart Testing)"
-    command: "ct --config .buildkite/ct.yaml lint"
-    agents:
-      charts: "true"
-    if: build.branch != "gh-pages"
+- command: "ct --config .buildkite/ct.version.yaml lint"
+  label: ":helm: Chart Version (Chart Testing)"
+  agents:
+    charts: "true"
+  if: build.branch != "gh-pages"
 
-  - label: ":package: Package Chart (Chart Releaser)"
-    commands:
-      - "mkdir .cr-release-packages"
-      - "ct --config .buildkite/ct.yaml list-changed | xargs -n1 cr --config .buildkite/cr.yaml package"
-    artifact_paths:
-      - ".cr-release-packages/*"
-    agents:
-      charts: "true"
-    if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+- command: "ct --config .buildkite/ct.yaml lint"
+  label: ":helm: Linting (Chart Testing)"
+  agents:
+    charts: "true"
+  if: build.branch != "gh-pages"
 
-  - label: ":github: Deploy Artifacts (Chart Releaser)"
-    commands:
-      - "mkdir .cr-release-packages"
-      - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
-      - "cr --config .buildkite/cr.yaml upload"
-    agents:
-      charts: "true"
-    if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+- wait: ~
+  continue_on_failure: true
 
-  - label: ":k8s: Publish Chart Index (Chart Releaser)"
-    commands:
-      - "mkdir .cr-release-packages .cr-index"
-      - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
-      - "cr --config .buildkite/cr.yaml index --push"
-    agents:
-      charts: "true"
-    if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+- commands:
+  - "mkdir .cr-release-packages"
+  - "ct --config .buildkite/ct.yaml list-changed | xargs -n1 cr --config .buildkite/cr.yaml package"
+  label: ":package: Package Chart (Chart Releaser)"
+  artifact_paths:
+  - ".cr-release-packages/*"
+  agents:
+    charts: "true"
+  if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+
+- commands:
+  - "mkdir .cr-release-packages"
+  - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
+  - "cr --config .buildkite/cr.yaml upload"
+  label: ":github: Deploy Artifacts (Chart Releaser)"
+  agents:
+    charts: "true"
+  depends_on:
+  - step: ":package: Package Chart (Chart Releaser)"
+  if: build.branch == "master" && build.env("CR_BYPASS") != "true"
+
+- commands:
+  - "mkdir .cr-release-packages .cr-index"
+  - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
+  - "git branch -d gh-pages"
+  - "cr --config .buildkite/cr.yaml index --push"
+  label: ":k8s: Publish Chart Index (Chart Releaser)"
+  agents:
+    charts: "true"
+  depends_on:
+  - step: ":github: Deploy Artifacts (Chart Releaser)"
+  if: build.branch == "master" && build.env("CR_BYPASS") != "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -4,12 +4,14 @@ env:
 
 steps:
 - command: "ct --config .buildkite/ct.version.yaml lint"
+  key: "lint-version"
   label: ":helm: Chart Version (Chart Testing)"
   agents:
     charts: "true"
   if: build.branch != "gh-pages"
 
 - command: "ct --config .buildkite/ct.yaml lint"
+  key: "lint"
   label: ":helm: Linting (Chart Testing)"
   agents:
     charts: "true"
@@ -21,6 +23,7 @@ steps:
 - commands:
   - "mkdir .cr-release-packages"
   - "ct --config .buildkite/ct.yaml list-changed | xargs -n1 cr --config .buildkite/cr.yaml package"
+  key: "package"
   label: ":package: Package Chart (Chart Releaser)"
   artifact_paths:
   - ".cr-release-packages/*"
@@ -32,11 +35,12 @@ steps:
   - "mkdir .cr-release-packages"
   - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
   - "cr --config .buildkite/cr.yaml upload"
+  key: "upload"
   label: ":github: Deploy Artifacts (Chart Releaser)"
   agents:
     charts: "true"
   depends_on:
-  - step: ":package: Package Chart (Chart Releaser)"
+  - step: "package"
   if: build.branch == "master" && build.env("CR_BYPASS") != "true"
 
 - commands:
@@ -44,9 +48,10 @@ steps:
   - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
   - "git branch -d gh-pages"
   - "cr --config .buildkite/cr.yaml index --push"
+  key: "index"
   label: ":k8s: Publish Chart Index (Chart Releaser)"
   agents:
     charts: "true"
   depends_on:
-  - step: ":github: Deploy Artifacts (Chart Releaser)"
+  - step: "upload"
   if: build.branch == "master" && build.env("CR_BYPASS") != "true"

--- a/.buildkite/scripts/pipeline.sh
+++ b/.buildkite/scripts/pipeline.sh
@@ -1,21 +1,9 @@
 #!/usr/bin/env bash
 
 if [[ "${BUILDKITE_BRANCH}" == "master" ]]; then
-  CHART_CHANGES=$(git diff --name-only HEAD~1 | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo false || echo true)
-  if [[ "${CHART_CHANGES}" == "true" ]]; then
-    export CR_BYPASS=false
-  else
-    export CR_BYPASS=true
-  fi
+  export CHART_CHANGES=$(git diff --name-only HEAD~1 | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo false || echo true)
 else
-  CHART_CHANGES=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo false || echo true)
-  export CR_BYPASS=true
-fi
-
-if [[ "${CHART_CHANGES}" == "true" ]]; then
-  export CT_BYPASS=false
-else
-  export CT_BYPASS=true
+  export CHART_CHANGES=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo false || echo true)
 fi
 
 envsubst < .buildkite/pipeline.yaml

--- a/.buildkite/scripts/pipeline.sh
+++ b/.buildkite/scripts/pipeline.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
 
-if [[ $BUILDKITE_BRANCH == "master" ]]; then
-  export CR_BYPASS=$(git diff --name-only HEAD~1 | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo true || echo false)
+if [[ "${BUILDKITE_BRANCH}" == "master" ]]; then
+  CHART_CHANGES=$(git diff --name-only HEAD~1 | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo false || echo true)
+  if [[ "${CHART_CHANGES}" == "true" ]]; then
+    export CR_BYPASS=false
+  else
+    export CR_BYPASS=true
+  fi
 else
+  CHART_CHANGES=$(git diff --name-only `git merge-base --fork-point origin/master` | sed -rn '/^charts\/[a-zA-Z0-9-]+\/(templates\/.*|crds\/.*|Chart.yaml|values.yaml|values.schema.json|LICENSE|README.md)/{q1}' && echo false || echo true)
   export CR_BYPASS=true
+fi
+
+if [[ "${CHART_CHANGES}" == "true" ]]; then
+  export CT_BYPASS=false
+else
+  export CT_BYPASS=true
 fi
 
 envsubst < .buildkite/pipeline.yaml


### PR DESCRIPTION
Adds a specific step for testing the version of the chart, allows for some concurrency for building the charts as well as ensures the order is executed correctly, forces deletion of the gh-pages branch locally to hopefully aleviate an out-of-sync git error, and adds a CT_BYPASS env var for future use and testing.