### PR TITLE
ci: only wait on master with changes

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -18,6 +18,7 @@ steps:
 
 - wait: ~
   continue_on_failure: true
+  if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
 - commands:
   - "mkdir .cr-release-packages"


### PR DESCRIPTION
Only add the wait step to the pipeline when it's needed, i.e. when the branch is master and there are changes to the charts.