### PR TITLE
ci: use hooks for majority of dir setup tasks

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-if [[ $BUILDKITE_LABEL == ":k8s: Publish Chart Index (Chart Releaser)" ]]; then
+if [[ "${BUILDKITE_STEP_KEY}" == "index" ]]; then
   echo "--- :broom: Cleaning repository"
 
-  rm -rf .cr-release-packages .cr-index
-  mkdir .cr-release-packages .cr-index
+  rm -rf .cr-index
+  mkdir .cr-index
 
-  if [[ ! -z $(git branch --list gh-pages) ]]; then
+  if [[ -n $(git branch --list gh-pages) ]]; then
     git branch --delete --force gh-pages
   fi
 

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -2,9 +2,18 @@
 
 set -eu
 
-if [[ $BUILDKITE_LABEL == ":k8s: Publish Chart Index (Chart Releaser)" ]]; then
+if [[ "${BUILDKITE_STEP_KEY}" == "index" ]]; then
   echo "--- :tada: Configuring git user"
 
   git config user.name "James Elliott"
   git config user.email "james-d-elliott@users.noreply.github.com"
+fi
+
+if [[ "${BUILDKITE_STEP_KEY}" == "upload" ]] || [[ "${BUILDKITE_STEP_KEY}" == "index" ]]; then
+  echo "--- :arrow_down: Downloading artifacts"
+
+  rm -rf .cr-release-packages
+  mkdir .cr-release-packages
+
+  buildkite-agent artifact download .cr-release-packages/* .cr-release-packages
 fi

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -20,9 +20,7 @@ steps:
   continue_on_failure: true
   if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
-- commands:
-  - "mkdir .cr-release-packages"
-  - "ct --config .buildkite/ct.yaml list-changed | xargs -n1 cr --config .buildkite/cr.yaml package"
+- command: "ct --config .buildkite/ct.yaml list-changed | xargs -n1 cr --config .buildkite/cr.yaml package"
   key: "package"
   label: ":package: Package Chart (Chart Releaser)"
   artifact_paths:
@@ -31,10 +29,7 @@ steps:
     charts: "true"
   if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
-- commands:
-  - "mkdir .cr-release-packages"
-  - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
-  - "cr --config .buildkite/cr.yaml upload"
+- command: "cr --config .buildkite/cr.yaml upload"
   key: "upload"
   label: ":github: Deploy Artifacts (Chart Releaser)"
   agents:
@@ -49,11 +44,7 @@ steps:
   - step: "upload"
   if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
-- commands:
-  - "sleep 120"
-  - "buildkite-agent artifact download .cr-release-packages/* .cr-release-packages"
-  - "sleep 120"
-  - "cr --config .buildkite/cr.yaml index --push"
+- command: "cr --config .buildkite/cr.yaml index --push"
   key: "index"
   label: ":k8s: Publish Chart Index (Chart Releaser)"
   agents:


### PR DESCRIPTION
Use the pre-command to download artifacts and setup packages directory, and use the step key instead of the label for detecting the step.