### PR TITLE
ci: ensure .cr-index exists, remove block, and update docs

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -34,6 +34,22 @@ if [[ $BUILDKITE_LABEL == ":k8s: Publish Chart Index (Chart Releaser)" ]] || [[ 
 fi
 ```
 
+## Additional Information
+
+The following table lists files used in CI/CD and their purposes.
+
+|File                          |Purpose                                                |
+|:----------------------------:|:-----------------------------------------------------:|
+|.yamllint.yaml                |Configuration for linting the yaml aspects of charts   |
+|.buildkite/cr.yaml            |Configuration for Chart Releaser                       |
+|.buildkite/ct.yaml            |Configuration for Chart Testing (linting tasks)        |
+|.buildkite/ct.version.yaml    |Configuration for Chart Testing (version check task)   |
+|.buildkite/chart_schema.yaml  |Configuration for checking the Chart.yaml schema       |
+|.buildkite/pipeline.yaml      |The Buildkite pipeline template which is envsubst'd    |
+|.buildkite/scripts/pipeline.sh|The script to derive env vars to envsubst pipeline.yaml|
+|.buildkite/hooks/post-checkout|This hook does tasks directly after the checkout       |
+|.buildkite/hooks/pre-command  |This hook does tasks directly before the actual step   |
+
 [hooks]: https://buildkite.com/docs/agent/v3/hooks
 
 [Buildkite]: https://buildkite.com

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -12,8 +12,8 @@ fi
 if [[ "${BUILDKITE_STEP_KEY}" == "upload" ]] || [[ "${BUILDKITE_STEP_KEY}" == "index" ]]; then
   echo "--- :arrow_down: Downloading artifacts"
 
-  rm -rf .cr-release-packages
-  mkdir .cr-release-packages
+  rm -rf .cr-release-packages .cr-index
+  mkdir -p .cr-release-packages .cr-index
 
   buildkite-agent artifact download .cr-release-packages/* .cr-release-packages
 fi

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -38,12 +38,6 @@ steps:
   - step: "package"
   if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
-- block: "Pre-index Block"
-  key: "block"
-  depends_on:
-  - step: "upload"
-  if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
-
 - command: "cr --config .buildkite/cr.yaml index --push"
   key: "index"
   label: ":k8s: Publish Chart Index (Chart Releaser)"


### PR DESCRIPTION
This should hopefully fix all remaining CI/CD chart releaser index issues.