### PR TITLE
fix(authelia): env indent and undefined blank values

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.5
+version: 0.3.6
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -131,7 +131,7 @@ spec:
         - name: AUTHELIA_IDENTITY_PROVIDERS_OIDC_ISSUER_PRIVATE_KEY_FILE
           value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "oidc-private-key") .) }}
         {{- end }}
-        {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 12 }}{{- end }}
+        {{- with $env := .Values.pod.env }}{{ toYaml $env | nindent 8 }}{{- end }}
         {{- with $probe := include "authelia.merge.probe" (merge (dict "Type" "startup" "Method" .Values.pod.probes.method "Probe" .Values.pod.probes.startup) .) }}
         {{- $probe | nindent 8 }}
         {{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -383,15 +383,15 @@ configMap:
   # labels:
   #   myLabel: myValue
 
-  # key: configuration.yaml
+  key: configuration.yaml
 
-  # existingConfigMap:
+  existingConfigMap: ""
 
   ##
   ## Port sets the configured port for the daemon, service, and the probes.
   ## Default is 9091 and should not need to be changed.
   ##
-  # port: 9091
+  port: 9091
 
   ##
   ## Server Configuration
@@ -423,7 +423,10 @@ configMap:
   ##
   ## Note: this parameter is optional. If not provided, user won't be redirected upon successful authentication.
   ## Default is https://www.<domain> (value at the top of the values.yaml).
+  default_redirection_url: ""
   # default_redirection_url: https://example.com
+
+  theme: light
 
   ##
   ## TOTP Configuration
@@ -923,6 +926,7 @@ configMap:
 ## and use the existingSecrets. All secrets can be stored in a single k8s secret if desired using the key option.
 ##
 secret:
+  existingSecret: ""
   # existingSecret: authelia
 
   annotations: {}

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -381,15 +381,15 @@ configMap:
   # labels:
   #   myLabel: myValue
 
-  # key: configuration.yaml
+  key: configuration.yaml
 
-  # existingConfigMap:
+  existingConfigMap: ""
 
   ##
   ## Port sets the configured port for the daemon, service, and the probes.
   ## Default is 9091 and should not need to be changed.
   ##
-  # port: 9091
+  port: 9091
 
   ##
   ## Server Configuration
@@ -421,7 +421,10 @@ configMap:
   ##
   ## Note: this parameter is optional. If not provided, user won't be redirected upon successful authentication.
   ## Default is https://www.<domain> (value at the top of the values.yaml).
+  default_redirection_url: ""
   # default_redirection_url: https://example.com
+
+  theme: light
 
   ##
   ## TOTP Configuration
@@ -921,6 +924,7 @@ configMap:
 ## and use the existingSecrets. All secrets can be stored in a single k8s secret if desired using the key option.
 ##
 secret:
+  existingSecret: ""
   # existingSecret: authelia
 
   annotations: {}


### PR DESCRIPTION
This fixes the env indent when additioanl env is defined. Additionally it adds blank defaults for various commented values which should work similar to if they did not exist in most instances, it just adds the ability in tools like argo-cd to see all of the values in advance.