### PR TITLE
fix(authelia): only render redis ha nodes when defined

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.7
+version: 0.3.8
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -96,7 +96,9 @@ data:
     {{- if $session.redis.high_availability.enabled }}
         high_availability:
           sentinel_name: {{ $session.redis.high_availability.sentinel_name }}
+          {{- if $session.redis.high_availability.nodes }}
           nodes: {{ toYaml $session.redis.high_availability.nodes | nindent 10 }}
+          {{- end }}
           route_by_latency: {{ $session.redis.high_availability.route_by_latency }}
           route_randomly: {{ $session.redis.high_availability.route_randomly }}
     {{- end }}


### PR DESCRIPTION
Previously this would render nodes with a list on a new line instead of rendering it on the same line. This change means it wont be rendered at all.