### PR TITLE
fix: missing blank defaults

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.8
+version: 0.3.9
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -1143,6 +1143,7 @@ secret:
         command: ""
 
 certificates:
+  existingSecret: ""
   # existingSecret: authelia
 
   annotations: {}
@@ -1201,13 +1202,16 @@ persistence:
   #   myLabel: myValue
 
   readOnly: false
-  # subPath:
-  # storageClass: "."
+  subPath: ""
 
-  # existingClaim:
+  existingClaim: ""
+  # existingClaim: my-claim-name
+
+  storageClass: ""
+  # storageClass: "my-storage-class"
 
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
 
   size: 100Mi
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1141,6 +1141,7 @@ secret:
         command: ""
 
 certificates:
+  existingSecret: ""
   # existingSecret: authelia
 
   annotations: {}
@@ -1199,10 +1200,13 @@ persistence:
   #   myLabel: myValue
 
   readOnly: false
-  # subPath:
-  # storageClass: "."
+  subPath: ""
 
-  # existingClaim:
+  existingClaim: ""
+  # existingClaim: my-claim-name
+
+  storageClass: ""
+  # storageClass: "my-storage-class"
 
   accessModes:
   - ReadWriteOnce


### PR DESCRIPTION
This just allows argo-cd and similar tools to auto-detect additional values without defining defaults.