### PR TITLE
feat(authelia): add config checksums to pod template meta

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.11
+version: 0.3.12
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -188,12 +188,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Returns the common annotations
 */}}
 {{- define "authelia.annotations" -}}
+    {{- $annotations := dict -}}
     {{- if .Values.annotations -}}
-        {{ toYaml .Values.annotations | indent 0 }}
-    {{- end }}
+        {{ $annotations = merge $annotations .Values.annotations -}}
+    {{- end -}}
     {{- if .Annotations -}}
-        {{ toYaml .Annotations | indent 0 }}
-    {{- end }}
+        {{ $annotations = merge $annotations .Annotations -}}
+    {{- end -}}
+    {{- if $annotations -}}
+        {{- toYaml $annotations | indent 0 -}}
+    {{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -44,12 +44,19 @@ spec:
   template:
     metadata:
       labels: {{ include "authelia.labels" (merge (dict "Labels" .Values.pod.labels) .) | nindent 8 }}
-      {{- $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.pod.annotations) .) -}}
-      {{- if or $annotations .Values.secret.vaultInjector.enabled }}
       annotations:
-    {{- if $annotations }}{{- $annotations | nindent 8 }}{{- end }}
-    {{- include "authelia.annotations.injector" . | nindent 8 }}
-    {{- end }}
+        {{- if (include "authelia.generate.configMap" .) }}
+        checksum/configMap: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+        {{- end }}
+        {{ if (include "authelia.enabled.secret" .) -}}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.pod.annotations) .) }}
+        {{- $annotations | nindent 8 }}
+        {{- end }}
+        {{- with $annotations := include "authelia.annotations.injector" . }}
+        {{- $annotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- with $tolerations := .Values.pod.tolerations }}
       tolerations: {{ toYaml $tolerations | nindent 8 }}


### PR DESCRIPTION
This adds the checksum of the generated ConfigMap and Secret to the deployment templates metadata annotations. This will cause the deployment to be updated triggering a RollingUpdate or Recreate.