### PR TITLE
fix(authelia): make redis username actually optional

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.16
+version: 0.3.17
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -85,7 +85,9 @@ data:
       redis:
         host: {{ $session.redis.host }}
         port: {{ default 6379 $session.redis.port }}
-        username: {{ default "authelia" $session.redis.username }}
+        {{- if not (eq $session.redis.username "") }}
+        username: {{ $session.redis.username }}
+        {{- end }}
         maximum_active_connections: {{ default 8 $session.redis.maximum_active_connections }}
         minimum_idle_connections: {{ default 0 $session.redis.minimum_idle_connections }}
     {{- if $session.redis.tls.enabled }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -728,7 +728,8 @@ configMap:
       port: 6379
 
       ## Optional username to be used with authentication.
-      username: authelia
+      # username: authelia
+      username: ""
 
       ## This is the Redis DB Index https://redis.io/commands/select (sometimes referred to as database number, DB, etc).
       database_index: 0

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -726,7 +726,8 @@ configMap:
       port: 6379
 
       ## Optional username to be used with authentication.
-      username: authelia
+      # username: authelia
+      username: ""
 
       ## This is the Redis DB Index https://redis.io/commands/select (sometimes referred to as database number, DB, etc).
       database_index: 0


### PR DESCRIPTION
This is so the username is only rendered if the username is not an empty string. Additionally it makes the default an empty string. This is so when users do not have the new redis v6 authentication enabled they can still use pre-v6 redis authentication.