### PR TITLE
fix(authelia): access control indentation

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.18
+version: 0.3.19
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -175,12 +175,12 @@ data:
     {{- if (eq (len .Values.configMap.access_control.networks) 0) }}
       networks: []
     {{- else }}
-      networks: {{ toYaml .Values.configMap.access_control.networks | nindent 8 }}
+      networks: {{ toYaml .Values.configMap.access_control.networks | nindent 6 }}
     {{- end }}
     {{- if (eq (len .Values.configMap.access_control.rules) 0) }}
       rules: []
     {{- else }}
-      rules: {{ toYaml .Values.configMap.access_control.rules | nindent 8 }}
+      rules: {{ toYaml .Values.configMap.access_control.rules | nindent 6 }}
     {{- end }}
     ...
     {{- end }}


### PR DESCRIPTION
This makes the indentation uniform with other areas of the configmap.