### PR TITLE
fix(authelia): secret volume includes non-existant smtp key

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.22
+version: 0.3.23
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -85,7 +85,9 @@ Returns true if smtp secret is configured.
     {{- if .Values.secret -}}
         {{- if .Values.secret.smtp -}}
             {{- if hasKey .Values.secret.smtp "value" -}}
-                {{- true -}}
+                {{- if not (eq .Values.secret.smtp.value "") -}}
+                    {{- true -}}
+                {{- end -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -15,7 +15,7 @@ data:
     {{- if or .Values.configMap.storage.postgres.enabled .Values.configMap.storage.mysql.enabled }}
     {{- .Values.secret.storage.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.storage.value) .) }}
     {{- end }}
-    {{- if .Values.configMap.authentication_backend.ldap }}
+    {{- if .Values.configMap.authentication_backend.ldap.enabled }}
     {{- .Values.secret.ldap.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.ldap.value) .) }}
     {{- end }}
     {{- if and .Values.configMap.session.redis.enabled .Values.configMap.session.redis.enabledSecret }}
@@ -24,7 +24,7 @@ data:
     {{- .Values.secret.redisSentinel.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.redisSentinel.value) .) }}
     {{- end }}
     {{- end }}
-    {{- if or (include "authelia.configured.smtp" .) .Values.configMap.notifier.smtp.enabledSecret }}
+    {{- if or (include "authelia.configured.smtp" .) (include "authelia.configured.smtpSecret" .) }}
     {{- .Values.secret.smtp.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "SecretValue" .Values.secret.smtp.value) .) }}
     {{- end }}
     {{- if or (include "authelia.configured.duo" .) (include "authelia.configured.duoSecret" .) }}


### PR DESCRIPTION
This prevents the SMTP secret keys being imported by the secrets volume when it is not enabled.