### PR TITLE
fix(authelia): incorrect end block in configmap

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.23
+version: 0.3.24
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -64,7 +64,6 @@ data:
     {{- if $auth.ldap.group_name_attribute }}
         group_name_attribute: {{ $auth.ldap.group_name_attribute }}
     {{- end }}
-    {{- end }}
     {{- if $auth.ldap.mail_attribute }}
         group_name_attribute: {{ $auth.ldap.mail_attribute }}
     {{- end }}
@@ -72,6 +71,7 @@ data:
         group_name_attribute: {{ $auth.ldap.display_name_attribute }}
     {{- end }}
         user: {{ $auth.ldap.user }}
+    {{- end }}
     {{- end }}
     {{- with $session := .Values.configMap.session }}
     session:


### PR DESCRIPTION
This is so the LDAP properties are only rendered when LDAP is enabled. A logic error in where the end block was placed caused an unwanted behaviour.