### PR TITLE
fix(authelia): incorrect mount path for configmap

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.24
+version: 0.4.0
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.3.23
+version: 0.3.24
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -116,7 +116,7 @@ The `*` below can be one of any of the following values:
 |secret.annotations            |A map of extra annotations to add to the Secret        |{}                     |
 |secret.labels                 |A map of extra labels to add to the Secret             |{}                     |
 |secret.existingSecret         |The name of the existing Secret instead of generating  |nil                    |
-|secret.mountPath              |The path where to mount all of the secrets             |/config/secrets        |
+|secret.mountPath              |The path where to mount all of the secrets             |/secrets               |
 |secret.*.key                  |The key in the secret where the JWT token is stored    |varies                 |
 |secret.*.value                |The value to inject into this secret when generating   |nil                    |
 |secret.*.filename             |The filename of this secret within the mountPath       |varies                 |
@@ -126,7 +126,7 @@ The `*` below can be one of any of the following values:
 |Parameter                                   |Description                                             |Default                |
 |:------------------------------------------:|:------------------------------------------------------:|:---------------------:|
 |secret.annotations                          |A map of extra annotations to add to the pod for Vault  |{}                     |
-|secret.mountPath                            |The path where to mount all of the secrets              |/config/secrets        |
+|secret.mountPath                            |The path where to mount all of the secrets              |/secrets               |
 |secret.vaultInjector.enabled                |Enables HashiCorp Vault Injector annotations            |false                  |
 |secret.vaultInjector.role                   |Vault role to use                                       |authelia               |
 |secret.vaultInjector.agent.status           |Value to inject to prevent further mutations            |update                 |

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -385,7 +385,7 @@ Returns the value of .SecretValue or a randomly generated one
 Returns the mountPath of the secrets.
 */}}
 {{- define "authelia.secret.mountPath" -}}
-    {{- default "/config/secrets" .Values.secret.mountPath -}}
+    {{- default "/secrets" .Values.secret.mountPath -}}
 {{- end -}}
 
 {{- define "authelia.secret.path" -}}
@@ -501,7 +501,7 @@ Returns the forwardAuth url
     {{- end -}}
     {{- $path := (include "authelia.path" .) | trimSuffix "/" -}}
     {{- $redirect := (include "authelia.ingressHostWithPath" .) -}}
-    {{- (printf "%s://%s.svc.%s%s/api/verify?rd=https://%s/#/" $scheme $host $cluster $path $redirect) -}}
+    {{- (printf "%s://%s.svc.%s%s/api/verify?rd=https://%s/" $scheme $host $cluster $path $redirect) -}}
 {{- end -}}
 
 {{/*

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -64,7 +64,6 @@ data:
     {{- if $auth.ldap.group_name_attribute }}
         group_name_attribute: {{ $auth.ldap.group_name_attribute }}
     {{- end }}
-    {{- end }}
     {{- if $auth.ldap.mail_attribute }}
         group_name_attribute: {{ $auth.ldap.mail_attribute }}
     {{- end }}
@@ -72,6 +71,7 @@ data:
         group_name_attribute: {{ $auth.ldap.display_name_attribute }}
     {{- end }}
         user: {{ $auth.ldap.user }}
+    {{- end }}
     {{- end }}
     {{- with $session := .Values.configMap.session }}
     session:

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -17,7 +17,7 @@ data:
     log_level: {{ default "info" .Values.configMap.log_level  }}
     default_redirection_url: {{ default (printf "https://www.%s" .Values.domain) .Values.configMap.default_redirection_url }}
     {{- if (include "authelia.enabled.certificatesSecret" .) }}
-    certificates_directory: /config/certificates
+    certificates_directory: /certificates
     {{- end }}
     server: {{ toYaml .Values.configMap.server | nindent 6 }}
     totp:
@@ -167,8 +167,14 @@ data:
     {{- end }}
     {{- end }}
     access_control:
-    {{- if and (eq (len .Values.configMap.access_control.rules) 0) (eq .Values.configMap.access_control.default_policy "bypass") }}
+    {{- if (eq (len .Values.configMap.access_control.rules) 0) }}
+      {{- if (eq .Values.configMap.access_control.default_policy "bypass") }}
       default_policy: one_factor
+      {{- else if (eq .Values.configMap.access_control.default_policy "deny") }}
+      default_policy: two_factor
+      {{- else }}
+      default_policy: {{ .Values.configMap.access_control.default_policy }}
+      {{- end }}
     {{- else }}
       default_policy: {{ .Values.configMap.access_control.default_policy }}
     {{- end }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
         {{- end }}
         command: ["authelia"]
         args:
-        - --config=/config/configuration.yaml
+        - --config=/configuration.yaml
         {{- with $resources :=.Values.pod.resources }}
         resources: {{ toYaml $resources | nindent 10 }}
         {{- end }}
@@ -162,15 +162,16 @@ spec:
           {{- end }}
           {{- with $subPathExpr := .Values.persistence.subPathExpr }}
           subPathExpr: {{ $subPathExpr }}
-            {{- end }}
-            {{- with $mountPropagation := .Values.persistence.mountPropagation }}
-            mountPropagation: {{ $mountPropagation }}
+          {{- end }}
+          {{- with $mountPropagation := .Values.persistence.mountPropagation }}
+          mountPropagation: {{ $mountPropagation }}
           {{- end }}
           {{- end }}
           {{- if (include "authelia.enabled.configMap" .) }}
-        - mountPath: /config
+        - mountPath: /configuration.yaml
           name: config
-          readOnly: false
+          readOnly: true
+          subPath: configuration.yaml
           {{- end }}
           {{- if not (include "authelia.enabled.injector" .) }}
         - mountPath: {{ include "authelia.secret.mountPath" . }}
@@ -178,7 +179,7 @@ spec:
           readOnly: true
           {{- end }}
           {{- if (include "authelia.enabled.certificatesSecret" .) }}
-        - mountPath: /config/certificates
+        - mountPath: /certificates
           name: certificates
           readOnly: true
           {{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -941,7 +941,7 @@ secret:
   # labels:
   #   myLabel: myValue
 
-  mountPath: /config/secrets
+  mountPath: /secrets
 
   ## Secrets.
   jwt:
@@ -992,7 +992,7 @@ secret:
     ## To see the annotations and what they do see: https://www.vaultproject.io/docs/platform/k8s/injector/annotations
     ## Annotations with a blank string do not get configured at all.
     ## Additional annotations can be configured via the secret.annotations: {} above.
-    ## Secrets are by default rendered in the /config/secrets directory. Changing this can be done via editing the
+    ## Secrets are by default rendered in the /secrets directory. Changing this can be done via editing the
     ## secret.mountPath value. You can alter the filenames with the secret.<secretName>.filename values.
     ## Secrets are loaded from vault path specified below with secrets.<secretName>.path values. Its format should be
     ## <SECRET_PATH>:<KEY_NAME>.

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -939,7 +939,7 @@ secret:
   # labels:
   #   myLabel: myValue
 
-  mountPath: /config/secrets
+  mountPath: /secrets
 
   ## Secrets.
   jwt:
@@ -990,7 +990,7 @@ secret:
     ## To see the annotations and what they do see: https://www.vaultproject.io/docs/platform/k8s/injector/annotations
     ## Annotations with a blank string do not get configured at all.
     ## Additional annotations can be configured via the secret.annotations: {} above.
-    ## Secrets are by default rendered in the /config/secrets directory. Changing this can be done via editing the
+    ## Secrets are by default rendered in the /secrets directory. Changing this can be done via editing the
     ## secret.mountPath value. You can alter the filenames with the secret.<secretName>.filename values.
     ## Secrets are loaded from vault path specified below with secrets.<secretName>.path values. Its format should be
     ## <SECRET_PATH>:<KEY_NAME>.


### PR DESCRIPTION
The mount path for the PVC was being overridden by the mount path for the configmap. This resolves this issue and also moves all non-dynamic data (i.e. certs, cecrets, configmaps) out of the config volume.