### PR TITLE
feat(authelia): version 4.29.1

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.1
+version: 0.4.2
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -23,6 +23,6 @@ maintainers:
   email: james-d-elliott@users.noreply.github.com
   url: https://github.com/james-d-elliott
 icon: https://avatars2.githubusercontent.com/u/59122411?s=200&v=4
-appVersion: 4.29.0
+appVersion: 4.29.1
 deprecated: false
 annotations: {}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the proper image name
 {{- define "authelia.image" -}}
     {{- $registryName := default "docker.io" .Values.image.registry -}}
     {{- $repositoryName := default "authelia/authelia" .Values.image.repository -}}
-    {{- $tag := default "latest" .Values.image.tag | toString -}}
+    {{- $tag := default .Chart.AppVersion .Values.image.tag | toString -}}
     {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.29.0
+  tag: 4.29.1
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -17,7 +17,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.29.0
+  tag: 4.29.1
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:


### PR DESCRIPTION
Bumps the version to latest and makes the default tag the .Chart.AppVersion value in preparation for removing it from the chart .Values and using the .Values.image.tag as an override.