### PR TITLE
feat(authelia): add option to use regular ingress with traefikcrd

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.2
+version: 0.4.3
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -23,6 +23,6 @@ maintainers:
   email: james-d-elliott@users.noreply.github.com
   url: https://github.com/james-d-elliott
 icon: https://avatars2.githubusercontent.com/u/59122411?s=200&v=4
-appVersion: 4.29.1
+appVersion: 4.29.2
 deprecated: false
 annotations: {}

--- a/charts/authelia/templates/NOTES.txt
+++ b/charts/authelia/templates/NOTES.txt
@@ -21,7 +21,18 @@ The following are the suggested annotations for 'ingress-nginx':
       proxy_set_header X-Forwarded-Method $request_method;
 
 {{- else if (include "authelia.enabled.ingress.traefik" .) }}
-You have selected the Traefik CRD to deploy the ingress. You can apply the {{ include "authelia.ingress.traefikCRD.middleware.name.chainAuth" . }} ({{ .Release.Namespace }} namespace) middleware to any Traefik ingress type in order to use Authelia auth with that ingress.
+You have selected the Traefik CRD to deploy the ingress.
+
+If you wish to protect an IngressRoute apply the following middleware:
+
+    middlewares:
+    - name: {{ include "authelia.ingress.traefikCRD.middleware.name.chainAuth" . }}
+      namespace: {{ .Release.Namespace }}
+
+If you wish to protect a regular Ingress apply the following annotation:
+
+    annotations:
+      traefik.ingress.kubernetes.io/router.middlewares: {{ (printf "%s-%s@kubernetescrd" (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) .Release.Namespace) }}
 
 You should be able to access Authelia soon via https://{{ include "authelia.ingressHostWithPath" . }} if everything is configured correctly in your values and the DNS record points to the correct location.
 {{- else -}}

--- a/charts/authelia/templates/ingress.yaml
+++ b/charts/authelia/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if (include "authelia.enabled.ingress.standard" .) }}
+{{- if (include "authelia.enabled.ingress.ingress" .) }}
 ---
 apiVersion: {{ include "capabilities.apiVersion.ingress" . }}
 kind: Ingress

--- a/charts/authelia/templates/traefikCRD/ingressRoute.yaml
+++ b/charts/authelia/templates/traefikCRD/ingressRoute.yaml
@@ -1,4 +1,4 @@
-{{ if (include "authelia.enabled.ingress.traefik" .) -}}
+{{ if (include "authelia.enabled.ingress.ingressRoute" .) -}}
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.29.1
+  tag: 4.29.2
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:
@@ -106,6 +106,9 @@ ingress:
 
   traefikCRD:
     enabled: false
+
+    ## Use a standard Ingress object, not an IngressRoute.
+    disableIngressRoute: true
 
     # matchOverride: Host(`auth.example.com`) && PathPrefix(`/`)
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -17,7 +17,7 @@
 image:
   registry: docker.io
   repository: authelia/authelia
-  tag: 4.29.1
+  tag: 4.29.2
   pullPolicy: IfNotPresent
   pullSecrets: []
   # pullSecrets:
@@ -104,6 +104,9 @@ ingress:
 
   traefikCRD:
     enabled: false
+
+    ## Use a standard Ingress object, not an IngressRoute.
+    disableIngressRoute: true
 
     # matchOverride: Host(`auth.example.com`) && PathPrefix(`/`)
 


### PR DESCRIPTION
Allows users to utilize the KubernetesIngress provider with Traefik and still create the CRD's for the middlewares etc.