### PR TITLE
feat(authelia): add fallback to semver compare for caps

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.3
+version: 0.4.4
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -526,22 +526,35 @@ Returns applicable Deployment/DaemonSet/Ingress API Version
 {{- end -}}
 
 {{/*
+Returns an overridable KubeVersion
+*/}}
+{{- define "capabilities.kubeVersion" -}}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- end -}}
+
+{{/*
 Returns applicable Deployment API version
+Deployment API Version Releases: apps/v1 in 1.9, apps/v1beta2 in 1.8, apps/v1beta1 prior.
 */}}
 {{- define "capabilities.apiVersion.deployment" -}}
-    {{- if .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
+    {{- if semverCompare .Capabilities.APIVersions.Has "apps/v1/Deployment" -}}
         {{- print "apps/v1" -}}
     {{- else if .Capabilities.APIVersions.Has "apps/v1beta2/Deployment" -}}
         {{- print "apps/v1beta2" -}}
     {{- else if .Capabilities.APIVersions.Has "apps/v1beta1/Deployment" -}}
         {{- print "apps/v1beta1" -}}
-    {{- else -}}
+    {{- else if semverCompare ">=1.9-0" (include "capabilities.kubeVersion" .) -}}
         {{- print "apps/v1" -}}
+    {{- else if semverCompare ">=1.8-0" (include "capabilities.kubeVersion" .) -}}
+        {{- print "apps/v1beta2" -}}
+    {{- else -}}
+        {{- print "apps/v1beta1" -}}
     {{- end }}
 {{- end -}}
 
 {{/*
 Returns applicable DaemonSet API version
+DaemonSet API Version Releases: apps/v1 in 1.9, apps/v1beta2 in 1.8, apps/v1beta1 prior.
 */}}
 {{- define "capabilities.apiVersion.daemonSet" -}}
     {{- if .Capabilities.APIVersions.Has "apps/v1/DaemonSet" -}}
@@ -550,13 +563,18 @@ Returns applicable DaemonSet API version
         {{- print "apps/v1beta2" -}}
     {{- else if .Capabilities.APIVersions.Has "apps/v1beta1/DaemonSet" -}}
         {{- print "apps/v1beta1" -}}
-    {{- else -}}
+    {{- else if semverCompare ">=1.9-0" (include "capabilities.kubeVersion" .) -}}
         {{- print "apps/v1" -}}
+    {{- else if semverCompare ">=1.8-0" (include "capabilities.kubeVersion" .) -}}
+        {{- print "apps/v1beta2" -}}
+    {{- else -}}
+        {{- print "apps/v1beta1" -}}
     {{- end }}
 {{- end -}}
 
 {{/*
 Returns applicable StatefulSet API version
+StatefulSet API Version Releases: apps/v1 in 1.9, apps/v1beta2 in 1.8, apps/v1beta1 prior.
 */}}
 {{- define "capabilities.apiVersion.statefulSet" -}}
     {{- if .Capabilities.APIVersions.Has "apps/v1/StatefulSet" -}}
@@ -565,21 +583,44 @@ Returns applicable StatefulSet API version
         {{- print "apps/v1beta2" -}}
     {{- else if .Capabilities.APIVersions.Has "apps/v1beta1/StatefulSet" -}}
         {{- print "apps/v1beta1" -}}
-    {{- else -}}
+    {{- else if semverCompare ">=1.9-0" (include "capabilities.kubeVersion" .) -}}
         {{- print "apps/v1" -}}
+    {{- else if semverCompare ">=1.8-0" (include "capabilities.kubeVersion" .) -}}
+        {{- print "apps/v1beta2" -}}
+    {{- else -}}
+        {{- print "apps/v1beta1" -}}
     {{- end }}
 {{- end -}}
 
 {{/*
 Returns applicable Ingress API version
+Ingress API Version Releases: networking.k8s.io/v1 in 1.19, extensions/v1beta1 prior.
 */}}
 {{- define "capabilities.apiVersion.ingress" -}}
     {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
         {{- print "networking.k8s.io/v1" -}}
     {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" -}}
         {{- print "networking.k8s.io/v1beta1" -}}
-    {{- else -}}
+    {{- else if semverCompare ">=1.19-0" (include "capabilities.kubeVersion" .) -}}
         {{- print "networking.k8s.io/v1" -}}
+    {{- else -}}
+        {{- print "networking.k8s.io/v1beta1" -}}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Returns applicable NetworkPolicy API version
+NetworkPolicy API Version Releases: networking.k8s.io/v1 in 1.9, extensions/v1beta1 prior.
+*/}}
+{{- define "capabilities.apiVersion.networkPolicy" -}}
+    {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/NetworkPolicy" -}}
+        {{- print "networking.k8s.io/v1" -}}
+    {{- else if .Capabilities.APIVersions.Has "extensions/v1beta1/NetworkPolicy" -}}
+        {{- print "extensions/v1beta1" -}}
+    {{- else if semverCompare ">=1.9-0" (include "capabilities.kubeVersion" .) -}}
+        {{- print "networking.k8s.io/v1" -}}
+    {{- else -}}
+        {{- print "extensions/v1beta1" -}}
     {{- end }}
 {{- end -}}
 

--- a/charts/authelia/templates/networkPolicy.yaml
+++ b/charts/authelia/templates/networkPolicy.yaml
@@ -1,6 +1,6 @@
 {{ if (include "authelia.enabled.networkPolicy" .) -}}
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "capabilities.apiVersion.networkPolicy" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ include "authelia.name" . }}


### PR DESCRIPTION
Capabilities generally can be detected via helm suffixed with their kind, however GitOps utilities like ArgoCD and flux do not forward these capabilities to the helm binary correctly, thus you have to fall back on semverCompare. This change should accurately detect based on version and should work for alpha / beta releases.