### PR TITLE
fix(authelia): invalid ingress default

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.5
+version: 0.4.6
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -108,7 +108,7 @@ ingress:
     enabled: false
 
     ## Use a standard Ingress object, not an IngressRoute.
-    disableIngressRoute: true
+    disableIngressRoute: false
 
     # matchOverride: Host(`auth.example.com`) && PathPrefix(`/`)
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -106,7 +106,7 @@ ingress:
     enabled: false
 
     ## Use a standard Ingress object, not an IngressRoute.
-    disableIngressRoute: true
+    disableIngressRoute: false
 
     # matchOverride: Host(`auth.example.com`) && PathPrefix(`/`)
 


### PR DESCRIPTION
Makes the TraefikCRD IngressRoute the default when TraefikCRD is enabled.