### PR TITLE
feat(authelia): make ghcr.io the default registry

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.6
+version: 0.4.7
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -16,7 +16,7 @@
 ## ref: https://hub.docker.com/r/authelia/authelia/tags/
 ##
 image:
-  registry: docker.io
+  registry: ghcr.io
   repository: authelia/authelia
   tag: 4.29.2
   pullPolicy: IfNotPresent

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -15,7 +15,7 @@
 ## ref: https://hub.docker.com/r/authelia/authelia/tags/
 ##
 image:
-  registry: docker.io
+  registry: ghcr.io
   repository: authelia/authelia
   tag: 4.29.2
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Uses ghcr.io as the default registry for images.