### PR TITLE
fix(authelia): fix incorrect kubernetescrd namespace/object order

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.6
+version: 0.4.7
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.7
+version: 0.4.8
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/NOTES.txt
+++ b/charts/authelia/templates/NOTES.txt
@@ -32,7 +32,7 @@ If you wish to protect an IngressRoute apply the following middleware:
 If you wish to protect a regular Ingress apply the following annotation:
 
     annotations:
-      traefik.ingress.kubernetes.io/router.middlewares: {{ (printf "%s-%s@kubernetescrd" .Release.Namespace) (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) }}
+      traefik.ingress.kubernetes.io/router.middlewares: {{ (printf "%s-%s@kubernetescrd" .Release.Namespace (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .)) }}
 
 You should be able to access Authelia soon via https://{{ include "authelia.ingressHostWithPath" . }} if everything is configured correctly in your values and the DNS record points to the correct location.
 {{- else -}}

--- a/charts/authelia/templates/NOTES.txt
+++ b/charts/authelia/templates/NOTES.txt
@@ -32,7 +32,7 @@ If you wish to protect an IngressRoute apply the following middleware:
 If you wish to protect a regular Ingress apply the following annotation:
 
     annotations:
-      traefik.ingress.kubernetes.io/router.middlewares: {{ (printf "%s-%s@kubernetescrd" (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) .Release.Namespace) }}
+      traefik.ingress.kubernetes.io/router.middlewares: {{ (printf "%s-%s@kubernetescrd" .Release.Namespace) (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) }}
 
 You should be able to access Authelia soon via https://{{ include "authelia.ingressHostWithPath" . }} if everything is configured correctly in your values and the DNS record points to the correct location.
 {{- else -}}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -154,7 +154,7 @@ Special Annotations Generator for the Ingress kind.
   {{- if .Values.ingress.traefikCRD.entryPoints -}}
   {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.entrypoints" (.Values.ingress.traefikCRD.entryPoints | join ",") -}}
   {{- end -}}
-  {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-%s@kubernetescrd" (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) .Release.Namespace) -}}
+  {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-%s@kubernetescrd" .Release.Namespace) (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) -}}
   {{- end -}}
   {{ include "authelia.annotations" (merge (dict "Annotations" $annotations) .) }}
 {{- end -}}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -154,7 +154,7 @@ Special Annotations Generator for the Ingress kind.
   {{- if .Values.ingress.traefikCRD.entryPoints -}}
   {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.entrypoints" (.Values.ingress.traefikCRD.entryPoints | join ",") -}}
   {{- end -}}
-  {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-%s@kubernetescrd" .Release.Namespace) (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .) -}}
+  {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-%s@kubernetescrd" .Release.Namespace (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .)) -}}
   {{- end -}}
   {{ include "authelia.annotations" (merge (dict "Annotations" $annotations) .) }}
 {{- end -}}


### PR DESCRIPTION
Fixes the order of the @kubernetescrd name of the annotations for the Ingress type.