### PR TITLE
fixing extraVolumes and extraVolumeMounts indentation

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.10
+version: 0.4.11
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -184,7 +184,7 @@ spec:
           readOnly: true
           {{- end }}
           {{- with $mounts := .Values.pod.extraVolumeMounts }}
-          {{ toYaml $mounts | indent 12 }}
+          {{- toYaml $mounts | nindent 8 }}
           {{- end }}
           {{- with $context := .Values.pod.securityContext.pod }}
           securityContext: {{ toYaml $context | nindent 12 }}
@@ -247,7 +247,7 @@ spec:
       - name: certificates
         secret:
           secretName: {{ include "authelia.names.certificatesSecret" . }}
-  {{- end }}
-  {{- with .Values.pod.extraVolumes }}
-  {{ toYaml . | indent 6 }}
-  {{- end }}
+        {{- end }}
+        {{- with .Values.pod.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+        {{- end }}


### PR DESCRIPTION
This PR fixes indentation on `extraVolumes` and `extraVolumeMounts` and therefor the following error messages which would appear when using these values:

```
Error: YAML parse error on authelia/templates/deployment.yaml: error converting YAML to JSON: yaml: line 98: mapping values are not allowed in this context 

Error: YAML parse error on authelia/templates/deployment.yaml: error converting YAML to JSON: yaml: line 113: mapping values are not allowed in this context
```