### PR TITLE
fix(authelia): typo in oidc client

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.4.11
+version: 0.4.12
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -158,7 +158,7 @@ data:
     {{- range $client := .Values.configMap.identity_providers.oidc.clients }}
         - id: {{ $client.id }}
           description: {{ default $client.id $client.description }}
-          authoriation_policy: {{ default "two_factor" $client.authorization_policy }}
+          authorization_policy: {{ default "two_factor" $client.authorization_policy }}
           secret: {{ default (randAlphaNum 128) $client.secret }}
           redirect_uris: {{ toYaml $client.redirect_uris | nindent 10 }}
           scopes: {{ toYaml (default (list "openid" "profile" "email" "groups") $client.scopes) | nindent 10 }}


### PR DESCRIPTION
This was a typo which would cause the OIDC configuration to not honor the policy set in the values.

Fixes #74