### PR TITLE
Remove updateStrategy in favor of strategy object

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.5.7
+version: 0.5.8
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -202,7 +202,7 @@ pod:
   replicas: 1
   revisionHistoryLimit: 5
 
-  updateStrategy: RollingUpdate
+  strategy: {}
 
   securityContext:
     container: {}


### PR DESCRIPTION
.Values.pod.updateStrategy is not being used anymore across the chart.

The leak of a strategy object causes https://github.com/authelia/chartrepo/issues/98