### PR TITLE
fix(authelia): limit replicas to StatefulSet and Deployment

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.6.2
+version: 0.6.3
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -12,7 +12,9 @@ spec:
   selector:
     matchLabels: {{ include "authelia.matchLabels" . | nindent 6 }}
   revisionHistoryLimit: {{ default 5 .Values.pod.revisionHistoryLimit }}
+  {{- if or (eq "StatefulSet" $kind) (eq "Deployment" $kind) }}
   replicas: {{ include "authelia.replicas" . }}
+  {{- end }}
   {{- if or (eq "Deployment" $kind) (eq "DaemonSet" $kind) }}
   minReadySeconds: {{ default 0 .Values.pod.minReadySeconds }}
   {{- end }}


### PR DESCRIPTION
Receiving the following error trying to upgrade to a version > 0.5.7:

```
Helm upgrade failed: error validating "": error validating data: ValidationError(DaemonSet.spec): unknown field "replicas" in io.k8s.api.apps.v1.DaemonSetSpec
```

It appears it is trying to set `replicas` on the default DaemonSet from `pod.kind`, and as far as I can tell that is not an option for a DaemonSet. This PR looks to limit setting the `replicas` to the StatefulSet and Deployment options.

Please let me know if this is not the right approach or it needs any other changes. 