### PR TITLE
fix(authelia): new totp options keys

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.7.1
+version: 0.7.2
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -35,8 +35,8 @@ data:
       {{- end }}
     totp:
       issuer: {{ default .Values.domain .Values.configMap.totp.issuer }}
-      algorithm: {{ default "sha1" .Values.configMap.totp.issuer }}
-      digits: {{ default 6 .Values.configMap.totp.issuer }}
+      algorithm: {{ default "sha1" .Values.configMap.totp.algorithm }}
+      digits: {{ default 6 .Values.configMap.totp.digits }}
       period: {{ default 30 .Values.configMap.totp.period }}
       skew: {{ default 1 .Values.configMap.totp.skew }}
     ntp:


### PR DESCRIPTION
This PR fixes a small C&P error, which breaks Authelia completely if you have set a value for `issuer`