### PR TITLE
fix(authelia): missing parenthesis around default invocation

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.7.2
+version: 0.7.3
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -34,7 +34,7 @@ data:
     {{- .Values.secret.duo.key | nindent 2 }}: {{ .Values.secret.duo.value | b64enc }}
     {{- end }}
     {{- if .Values.configMap.identity_providers.oidc.enabled }}
-    {{- .Values.secret.oidcHMACSecret.key | nindent 2}}: {{ default (randAlphaNum 32) default (get $secretData .Values.secret.oidcHMACSecret.key) .Values.secret.oidcHMACSecret.value | b64enc }}
-    {{- .Values.secret.oidcPrivateKey.key | nindent 2}}: {{ default (genPrivateKey "rsa") default (get $secretData .Values.secret.oidcPrivateKey.key) .Values.secret.oidcPrivateKey.value | b64enc }}
+    {{- .Values.secret.oidcHMACSecret.key | nindent 2}}: {{ default (randAlphaNum 32) (default (get $secretData .Values.secret.oidcHMACSecret.key) .Values.secret.oidcHMACSecret.value) | b64enc }}
+    {{- .Values.secret.oidcPrivateKey.key | nindent 2}}: {{ default (genPrivateKey "rsa") (default (get $secretData .Values.secret.oidcPrivateKey.key) .Values.secret.oidcPrivateKey.value) | b64enc }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
Fixes:
```
Error: template: authelia/templates/secret.yaml:37:86: executing "authelia/templates/secret.yaml" at <default>: wrong number of args for default: want at least 1 got 0
```
Caused by recent changes here:
https://github.com/authelia/chartrepo/commit/17e7b94bb3b11fe0e7ab1b04d37af04cd2959724#diff-9189c2f5c1b19f1988198e0c692eea37875a6bc90ce03513fbcfa995a3238b91L34