### PR TITLE
fix(authelia): ingress logic outdated

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.7.7
+version: 0.7.8
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/ingress.yaml
+++ b/charts/authelia/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if (include "authelia.enabled.ingress.ingress" .) }}
 ---
-apiVersion: {{ include "capabilities.apiVersion.ingress" . }}
+{{- $apiVersion := (include "capabilities.apiVersion.ingress" .) }}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ include "authelia.name" . }}
@@ -9,7 +10,7 @@ metadata:
   annotations: {{ $annotations | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+  {{- if eq $apiVersion "networking.k8s.io/v1" }}
   {{- with $className := .Values.ingress.className }}
   ingressClassName: {{ $className }}
   {{- end }}
@@ -19,11 +20,11 @@ spec:
       http:
         paths:
           - path: {{ (include "authelia.path" .) }}
-            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
             pathType: Prefix
             {{- end }}
             backend:
-              {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
               service:
                 name: {{ include "authelia.name" . }}
                 port:


### PR DESCRIPTION
As 1.18 and 1.19 are no longer versions of k8s in the support lifecycle this makes the networking.k8s.io/v1 api version the default for ingress types.