### PR TITLE
fix(authelia): prevent traefik auto annotations overriding custom ones

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.7.9
+version: 0.7.10
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -125,10 +125,12 @@ Special Annotations Generator for the Ingress kind.
   {{- $annotations = set $annotations "kubernetes.io/tls-acme" "true" -}}
   {{- end -}}
   {{- if and .Values.ingress.traefikCRD .Values.ingress.traefikCRD.disableIngressRoute -}}
-  {{- if .Values.ingress.traefikCRD.entryPoints -}}
-  {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.entrypoints" (.Values.ingress.traefikCRD.entryPoints | join ",") -}}
+  {{- if and (gt (len .Values.ingress.traefikCRD.entryPoints) 0) (not (hasKey $annotations "traefik.ingress.kubernetes.io/router.entryPoints")) -}}
+  {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.entryPoints" (.Values.ingress.traefikCRD.entryPoints | join ",") -}}
   {{- end -}}
+  {{- if not (hasKey $annotations "traefik.ingress.kubernetes.io/router.middlewares") }}
   {{- $annotations = set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (printf "%s-%s@kubernetescrd" .Release.Namespace (include "authelia.ingress.traefikCRD.middleware.name.chainIngress" .)) -}}
+  {{- end }}
   {{- end -}}
   {{ include "authelia.annotations" (merge (dict "Annotations" $annotations) .) }}
 {{- end -}}


### PR DESCRIPTION
Ensures that custom annotations on the ingress completely replace any automatic ones. However it's recommended that you utilize the entryPoints and middlewares options instead.