### PR TITLE
fix(authelia): add version override

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.12
+version: 0.8.13
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -222,7 +222,7 @@ data:
         authorize_code_lifespan: {{ default "1m" .Values.configMap.identity_providers.oidc.authorize_code_lifespan }}
         id_token_lifespan: {{ default "1h" .Values.configMap.identity_providers.oidc.id_token_lifespan }}
         refresh_token_lifespan: {{ default "90m" .Values.configMap.identity_providers.oidc.refresh_token_lifespan }}
-        {{- if not (semverCompare (.Values.image.tag | default .Chart.AppVersion  | toString) "4.34.0") }}
+        {{- if (semverCompare ">=4.34.1" (.Values.versionOverride | default .Chart.AppVersion | toString)) }}
         enforce_pkce: {{ .Values.configMap.identity_providers.oidc.enforce_pkce | default "public_clients_only" }}
         enable_pkce_plain_challenge: {{ .Values.configMap.identity_providers.oidc.enable_pkce_plain_challenge | default false }}
         {{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -12,6 +12,12 @@
 ##   - session: memory
 ##   - notification: filesystem (yaml)
 
+## Version Override allows changing some chart characteristics that render only on specific versions.
+## This does NOT affect the image used, please see the below image section instead for this.
+## If this value is not specified, it's assumed the appVersion of the chart is the version.
+## The format of this value  is x.x.x, for example 4.100.0.
+versionOverride: ""
+
 ## Image Parameters
 ## ref: https://hub.docker.com/r/authelia/authelia/tags/
 ##

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -11,6 +11,12 @@
 ##   - storage: MySQL
 ##   - session: redis
 
+## Version Override allows changing some chart characteristics that render only on specific versions.
+## This does NOT affect the image used, please see the below image section instead for this.
+## If this value is not specified, it's assumed the appVersion of the chart is the version.
+## The format of this value  is x.x.x, for example 4.100.0.
+versionOverride: ""
+
 ## Image Parameters
 ## ref: https://hub.docker.com/r/authelia/authelia/tags/
 ##


### PR DESCRIPTION
This is to eliminate options in the configmap for older versions. It will take time to add these specific values.