### PR TITLE
fix(authelia): image pull secrets is in wrong spec

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.13
+version: 0.8.14
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -87,11 +87,6 @@ spec:
       - name: authelia
         image: {{ include "authelia.image" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
-        {{- with $pullSecrets := .Values.image.pullSecrets }}
-        imagePullSecrets: {{- range $k, $secretName := $pullSecrets }}
-        - name: {{ $secretName }}
-        {{- end }}
-        {{- end }}
         {{- if .Values.secret.vaultInjector.enabled }}
         securityContext:
           runAsUser: 1000
@@ -205,6 +200,11 @@ spec:
         {{- end }}
       {{- with $context := .Values.pod.securityContext.pod }}
         securityContext: {{ toYaml $context | nindent 10 }}
+      {{- end }}
+      {{- with $pullSecrets := .Values.image.pullSecrets }}
+      imagePullSecrets: {{- range $k, $secretName := $pullSecrets }}
+      - name: {{ $secretName }}
+      {{- end }}
       {{- end }}
       volumes:
       {{- if (include "authelia.enabled.persistentVolumeClaim" .) }}


### PR DESCRIPTION
Image pull secrets is placed inside Daemonset.spec.template.spec.container[0]. imagePullSecrets rather should be in spec.template.spec. imagePullSecrets

**Description of the change**
The Image pull secret is not recognized as valid configuration when placed under Daemonset.spec.template.spec.container[0]
Changing the path to Daemonset.spec.template.spec. imagePullSecrets solves the issue.

**Benefits**
Imagepull secrets works as expected.


- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/)
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)


**Signed-off-by**: Harish Desetti <desettih@gmail.com>