### PR TITLE
Changed the configMap helm chart template to not populate  totp and webauthn configuration blocks when they are disabled in values.yaml

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.13
+version: 0.8.14
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -87,11 +87,6 @@ spec:
       - name: authelia
         image: {{ include "authelia.image" . }}
         imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
-        {{- with $pullSecrets := .Values.image.pullSecrets }}
-        imagePullSecrets: {{- range $k, $secretName := $pullSecrets }}
-        - name: {{ $secretName }}
-        {{- end }}
-        {{- end }}
         {{- if .Values.secret.vaultInjector.enabled }}
         securityContext:
           runAsUser: 1000
@@ -205,6 +200,11 @@ spec:
         {{- end }}
       {{- with $context := .Values.pod.securityContext.pod }}
         securityContext: {{ toYaml $context | nindent 10 }}
+      {{- end }}
+      {{- with $pullSecrets := .Values.image.pullSecrets }}
+      imagePullSecrets: {{- range $k, $secretName := $pullSecrets }}
+      - name: {{ $secretName }}
+      {{- end }}
       {{- end }}
       volumes:
       {{- if (include "authelia.enabled.persistentVolumeClaim" .) }}


### PR DESCRIPTION
Linked to the issue #146 