### PR TITLE
feat: omit config values not valid for the specific version

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.15
+version: 0.8.16
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -36,6 +36,13 @@ Return the name for this chart
 {{- end -}}
 
 {{/*
+Return the app version.
+*/}}
+{{- define "authelia.version" -}}
+    {{ .Values.versionOverride | default .Chart.AppVersion | toString }}
+{{- end -}}
+
+{{/*
 Returns the name of the forwardAuth Middleware for forward auth which gets applied to other IngressRoutes.
 */}}
 {{- define "authelia.ingress.traefikCRD.middleware.name.forwardAuth" -}}
@@ -167,7 +174,7 @@ Returns the common labels
 */}}
 {{- define "authelia.labels" -}}
     {{ include "authelia.matchLabels" . }}
-app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/version: {{ include "authelia.version" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "authelia.chart" . }}
     {{- if .Values.labels }}

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -22,50 +22,56 @@ data:
       {{- if not (eq "" (default "" .Values.configMap.server.path)) }}
       path: {{ .Values.configMap.server.path }}
       {{- end }}
+      {{- if semverCompare ">=4.33.0" (include "authelia.version" .) }}
+      asset_path: {{ .Values.configMap.server.asset_path | default "" | quote }}
+      {{- end }}
+      {{- if (semverCompare ">=4.34.0" (include "authelia.version" .)) }}
       headers:
         csp_template: {{ .Values.configMap.server.headers.csp_template | default "" | quote }}
+      {{- end }}
       read_buffer_size: {{ default 4096 .Values.configMap.server.read_buffer_size }}
       write_buffer_size: {{ default 4096 .Values.configMap.server.write_buffer_size }}
-      enable_pprof: {{ default false .Values.configMap.server.enable_pprof }}
-      enable_expvars: {{ default false .Values.configMap.server.enable_expvars }}
+      enable_pprof: {{ .Values.configMap.server.enable_pprof | default false }}
+      enable_expvars: {{ .Values.configMap.server.enable_expvars | default false }}
     log:
       level: {{ default "info" .Values.configMap.log.level }}
       format: {{ default "text" .Values.configMap.log.format }}
-      {{- if not (eq "" (default "" .Values.configMap.log.file_path)) }}
-      file_path: {{ .Values.configMap.log.file_path }}
+      file_path: {{ .Values.configMap.log.file_path | default "" | quote }}
       keep_stdout: true
-      {{- end }}
     totp:
-      {{- if eq .Values.configMap.totp.disable true }}
-      disable: true
-      {{- else }}
-      disable: false
+      {{- if semverCompare ">=4.34.0" (include "authelia.version" .) }}
+      disable: {{ .Values.configMap.totp.disable | default false }}
+      {{- end }}
       issuer: {{ default .Values.domain .Values.configMap.totp.issuer }}
+      {{- if semverCompare ">=4.33.0" (include "authelia.version" .) }}
       algorithm: {{ default "sha1" .Values.configMap.totp.algorithm }}
       digits: {{ default 6 .Values.configMap.totp.digits }}
+      {{- end }}
       period: {{ default 30 .Values.configMap.totp.period }}
       skew: {{ default 1 .Values.configMap.totp.skew }}
-      {{- end }}
+   {{- if semverCompare ">=4.34.0" (include "authelia.version" .) }}
     webauthn:
-      {{- if eq .Values.configMap.webauthn.disable true }}
-      disable: true
-      {{- else }}
-      disable: false
+      disable: {{ .Values.configMap.webauthn.disable | default false }}
       display_name: {{ .Values.configMap.webauthn.display_name | default "Authelia" }}
       attestation_conveyance_preference: {{ .Values.configMap.webauthn.attestation_conveyance_preference | default "indirect" }}
       user_verification: {{ .Values.configMap.webauthn.user_verification | default "preferred" }}
       timeout: {{ .Values.configMap.webauthn.timeout | default "60s" }}
-      {{- end }}
+    {{- end }}
+    {{- if semverCompare ">=4.31.0" (include "authelia.version" .) }}
     ntp:
       address: {{ default "time.cloudflare.com:123" .Values.configMap.ntp.address }}
       version: {{ default 3 .Values.configMap.ntp.version }}
       max_desync: {{ default "3s" .Values.configMap.ntp.max_desync }}
       disable_startup_check: {{ default false .Values.configMap.ntp.disable_startup_check }}
       disable_failure: {{ default false .Values.configMap.ntp.disable_failure }}
+    {{- end }}
     {{- if include "authelia.configured.duo" . }}
     duo_api:
       hostname: {{ .Values.configMap.duo_api.hostname }}
       integration_key: {{ .Values.configMap.duo_api.integration_key }}
+      {{- if semverCompare ">=4.33.0" (include "authelia.version" .) }}
+      enable_self_enrollment: {{ .Values.configMap.duo_api.enable_self_enrollment | default false }}
+      {{- end }}
     {{- end }}
     {{- with $auth := .Values.configMap.authentication_backend }}
     authentication_backend:
@@ -146,8 +152,8 @@ data:
           {{- if $session.redis.high_availability.nodes }}
           nodes: {{ toYaml $session.redis.high_availability.nodes | nindent 10 }}
           {{- end }}
-          {{- if not (eq $session.redis.high_availability.username "") }}
-          sentinel_username: {{ $session.redis.high_availability.username }}
+          {{- if semverCompare ">=4.33.0" (include "authelia.version" $) }}
+          sentinel_username: {{ $session.redis.high_availability.username | default "" | quote }}
           {{- end }}
           route_by_latency: {{ $session.redis.high_availability.route_by_latency }}
           route_randomly: {{ $session.redis.high_availability.route_randomly }}
@@ -167,27 +173,31 @@ data:
         port: {{ default 3306 $storage.mysql.port }}
         database: {{ default "authelia" $storage.mysql.database }}
         username: {{ default "authelia" $storage.mysql.username }}
+        {{- if semverCompare ">=4.31.0" (include "authelia.version" $) }}
         timeout: {{ default "5s" $storage.mysql.timeout }}
+        {{- end }}
       {{- end }}
       {{- if $storage.postgres.enabled }}
       postgres:
         host: {{ $storage.postgres.host }}
         port: {{ default 5432 $storage.postgres.port }}
         database: {{ default "authelia" $storage.postgres.database }}
+        {{- if semverCompare ">=4.33.0" (include "authelia.version" $) }}
         schema: {{ default "public" $storage.postgres.schema }}
+        {{- end }}
         username: {{ default "authelia" $storage.postgres.username }}
+        {{- if semverCompare ">=4.31.0" (include "authelia.version" $) }}
         timeout: {{ default "5s" $storage.postgres.timeout }}
+        {{- end }}
+        {{- if semverCompare ">=4.33.0" (include "authelia.version" $) }}
         ssl:
-          mode: {{ default "disable" $storage.postgres.sslmode }}
-          {{- if and $storage.postgres.ssl.root_certificate (not (eq $storage.postgres.ssl.root_certificate "")) }}
-          root_certificate: {{ $storage.postgres.ssl.root_certificate }}
-          {{- end }}
-          {{- if and $storage.postgres.ssl.certificate (not (eq $storage.postgres.ssl.certificate "")) }}
-          certificate: {{ $storage.postgres.ssl.certificate }}
-          {{- end }}
-          {{- if and $storage.postgres.ssl.key (not (eq $storage.postgres.ssl.key "")) }}
-          key: {{ $storage.postgres.ssl.key }}
-          {{- end }}
+          mode: {{ $storage.postgres.ssl.mode | default "disable" | quote }}
+          root_certificate: {{ $storage.postgres.ssl.root_certificate | default "" | quote }}
+          certificate: {{ $storage.postgres.ssl.certificate | default "" | quote }}
+          key: {{ $storage.postgres.ssl.key | default "" | quote }}
+        {{- else }}
+        sslmode: {{ $storage.postgres.ssl.mode | default "disable" | quote }}
+        {{- end }}
       {{- end }}
     {{- end }}
     {{- with $notifier := .Values.configMap.notifier }}
@@ -201,7 +211,9 @@ data:
       smtp:
         host: {{ $notifier.smtp.host }}
         port: {{ default 25 $notifier.smtp.port }}
+        {{- if semverCompare ">=4.31.0" (include "authelia.version" $) }}
         timeout: {{ default "5s" $notifier.smtp.timeout }}
+        {{- end }}
         username: {{ $notifier.smtp.username }}
         sender: {{ $notifier.smtp.sender }}
         identifier: {{ $notifier.smtp.identifier }}
@@ -222,7 +234,7 @@ data:
         authorize_code_lifespan: {{ default "1m" .Values.configMap.identity_providers.oidc.authorize_code_lifespan }}
         id_token_lifespan: {{ default "1h" .Values.configMap.identity_providers.oidc.id_token_lifespan }}
         refresh_token_lifespan: {{ default "90m" .Values.configMap.identity_providers.oidc.refresh_token_lifespan }}
-        {{- if (semverCompare ">=4.34.1" (.Values.versionOverride | default .Chart.AppVersion | toString)) }}
+        {{- if semverCompare ">=4.34.1" (include "authelia.version" .) }}
         enforce_pkce: {{ .Values.configMap.identity_providers.oidc.enforce_pkce | default "public_clients_only" }}
         enable_pkce_plain_challenge: {{ .Values.configMap.identity_providers.oidc.enable_pkce_plain_challenge | default false }}
         {{- end }}
@@ -236,9 +248,7 @@ data:
           {{- if not $client.public }}
           secret: {{ default (randAlphaNum 128) $client.secret }}
           {{- end }}
-          {{- if hasKey $client "public" }}
-          public: {{ $client.public }}
-          {{- end }}
+          public: {{ $client.public | default false }}
           authorization_policy: {{ default "two_factor" $client.authorization_policy }}
           redirect_uris: {{ toYaml $client.redirect_uris | nindent 10 }}
           {{- if hasKey $client "audience" }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -116,8 +116,10 @@ spec:
         - name: AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
           value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "smtp") .) }}
         {{- end }}
+        {{- if semverCompare ">=4.33.0" (include "authelia.version" .) }}
         - name: AUTHELIA_STORAGE_ENCRYPTION_KEY_FILE
           value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "storageEncryptionKey") .) }}
+        {{- end }}
         {{- if .Values.configMap.storage.postgres.enabled }}
         - name: AUTHELIA_STORAGE_POSTGRES_PASSWORD_FILE
           value: {{ include "authelia.secret.fullPath" (merge (dict "Secret" "storage") .) }}
@@ -237,8 +239,10 @@ spec:
             path: {{ include "authelia.secret.path" (merge (dict "Secret" "jwt") .) }}
           - key: {{ default "SESSION_ENCRYPTION_KEY" .Values.secret.session.key }}
             path: {{ include "authelia.secret.path" (merge (dict "Secret" "session") .) }}
+          {{- if semverCompare ">=4.33.0" (include "authelia.version" .) }}
           - key: {{ default "STORAGE_ENCRYPTION_KEY" .Values.secret.storageEncryptionKey.key }}
             path: {{ include "authelia.secret.path" (merge (dict "Secret" "storageEncryptionKey") .) }}
+          {{- end }}
           {{- if or .Values.configMap.storage.postgres.enabled .Values.configMap.storage.mysql.enabled }}
           - key: {{ default "STORAGE_PASSWORD" .Values.secret.storage.key }}
             path: {{ include "authelia.secret.path" (merge (dict "Secret" "storage") .) }}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -17,7 +17,9 @@ data:
     {{- if or .Values.configMap.storage.postgres.enabled .Values.configMap.storage.mysql.enabled }}
     {{- .Values.secret.storage.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "LookupValue" (get $secretData .Values.secret.storage.key) "SecretValue" .Values.secret.storage.value) .) }}
     {{- end }}
+    {{- if semverCompare ">=4.33.0" (include "authelia.version" .) }}
     {{- .Values.secret.storageEncryptionKey.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "LookupValue" (get $secretData .Values.secret.storageEncryptionKey.key) "SecretValue" .Values.secret.storageEncryptionKey.value) .) }}
+    {{- end }}
     {{- if .Values.configMap.authentication_backend.ldap.enabled }}
     {{- .Values.secret.ldap.key | nindent 2 }}: {{ include "authelia.secret.standard" (merge (dict "LookupValue" (get $secretData .Values.secret.ldap.key) "SecretValue" .Values.secret.ldap.value) .) }}
     {{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -16,6 +16,11 @@
 ## This does NOT affect the image used, please see the below image section instead for this.
 ## If this value is not specified, it's assumed the appVersion of the chart is the version.
 ## The format of this value  is x.x.x, for example 4.100.0.
+##
+## Important Points:
+##   - No guarantees of support for prior versions is given. The chart is intended to be used with the AppVersion.
+##   - Does not and will not support any version prior to 4.30.0 due to a significant refactor of the configuration
+##     system.
 versionOverride: ""
 
 ## Image Parameters
@@ -414,6 +419,15 @@ configMap:
     ##
     port: 9091
 
+    ## Set the single level path Authelia listens on.
+    ## Must be alphanumeric chars and should not contain any slashes.
+    path: ""
+
+    ## Set the path on disk to Authelia assets.
+    ## Useful to allow overriding of specific static assets.
+    # asset_path: /config/assets/
+    asset_path: ""
+
     ## Customize Authelia headers.
     headers:
       ## Read the Authelia docs before setting this advanced option.
@@ -426,9 +440,6 @@ configMap:
     ## Write buffer size does the same for outgoing responses.
     read_buffer_size: 4096
     write_buffer_size: 4096
-    ## Set the single level path Authelia listens on.
-    ## Must be alphanumeric chars and should not contain any slashes.
-    path: ""
 
   log:
     ## Level of verbosity for logs: info, debug, trace.
@@ -440,6 +451,7 @@ configMap:
     ## TODO: Statefulness check should check if this is set, and the configMap should enable it.
     ## File path where the logs will be written. If not set logs are written to stdout.
     # file_path: /config/authelia.log
+    file_path: ""
 
   ## Default redirection URL
   ##
@@ -540,6 +552,7 @@ configMap:
     enabled: false
     hostname: api-123456789.example.com
     integration_key: ABCDEF
+    enable_self_enrollment: false
 
   ##
   ## Authentication Backend Provider Configuration
@@ -943,7 +956,11 @@ configMap:
       port: 5432
       database: authelia
       username: authelia
-      sslmode: disable
+      ssl:
+        mode: disable
+        root_certificate: ""
+        certificate: ""
+        key: ""
       timeout: 5s
 
   ##

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -15,6 +15,11 @@
 ## This does NOT affect the image used, please see the below image section instead for this.
 ## If this value is not specified, it's assumed the appVersion of the chart is the version.
 ## The format of this value  is x.x.x, for example 4.100.0.
+##
+## Important Points:
+##   - No guarantees of support for prior versions is given. The chart is intended to be used with the AppVersion.
+##   - Does not and will not support any version prior to 4.30.0 due to a significant refactor of the configuration
+##     system.
 versionOverride: ""
 
 ## Image Parameters
@@ -412,6 +417,15 @@ configMap:
     ##
     port: 9091
 
+    ## Set the single level path Authelia listens on.
+    ## Must be alphanumeric chars and should not contain any slashes.
+    path: ""
+
+    ## Set the path on disk to Authelia assets.
+    ## Useful to allow overriding of specific static assets.
+    # asset_path: /config/assets/
+    asset_path: ""
+
     ## Customize Authelia headers.
     headers:
       ## Read the Authelia docs before setting this advanced option.
@@ -424,9 +438,6 @@ configMap:
     ## Write buffer size does the same for outgoing responses.
     read_buffer_size: 4096
     write_buffer_size: 4096
-    ## Set the single level path Authelia listens on.
-    ## Must be alphanumeric chars and should not contain any slashes.
-    path: ""
 
   log:
     ## Level of verbosity for logs: info, debug, trace.
@@ -438,6 +449,7 @@ configMap:
     ## TODO: Statefulness check should check if this is set, and the configMap should enable it.
     ## File path where the logs will be written. If not set logs are written to stdout.
     # file_path: /config/authelia.log
+    file_path: ""
 
   ## Default redirection URL
   ##
@@ -538,6 +550,7 @@ configMap:
     enabled: false
     hostname: api-123456789.example.com
     integration_key: ABCDEF
+    enable_self_enrollment: false
 
   ##
   ## Authentication Backend Provider Configuration


### PR DESCRIPTION
This adds several semver checks to ensure that only config values for the relevant Authelia version are rendered. This can be controlled by changing the versionOverride value otherwise it uses the chart AppVersion value.