### PR TITLE
fix(authelia): argon2 memory linked to parallelism

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.43
+version: 0.8.44
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -136,7 +136,7 @@ data:
             {{- else }}
             memory: {{ $auth.file.password.argon2.memory | default 65536 }}
             {{- end }}
-            parallelism: {{ $auth.file.password.parallelism | default $auth.file.password.argon2.memory | default 4 }}
+            parallelism: {{ $auth.file.password.memory | default $auth.file.password.argon2.memory | default 4 }}
             key_length: {{ $auth.file.password.key_length | default $auth.file.password.argon2.key_length | default 32 }}
             salt_length: {{ $auth.file.password.salt_length | default $auth.file.password.argon2.salt_length | default 16 }}
           scrypt:


### PR DESCRIPTION
This fixes an issue where the argon2 memory config is  used instead of parallelism, causing an error.

Fixes #186 