### PR TITLE
fix(authelia): sha2crypt iterations incorrectly rendered

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.45
+version: 0.8.46
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -152,7 +152,7 @@ data:
           sha2crypt:
             variant: {{ $auth.file.password.sha2crypt.variant | default "sha512" | squote }}
             iterations: {{ $auth.file.password.sha2crypt.iterations | default 50000 }}
-            salt_length: {{ $auth.file.password.sha2crypt.salt_length | default 16 }}
+            salt_length: {{ $auth.file.password.salt_length | default $auth.file.password.sha2crypt.salt_length | default 16 }}
           bcrypt:
             variant: {{ $auth.file.password.bcrypt.variant | default "standard" | squote }}
             cost: {{ $auth.file.password.bcrypt.cost | default 12 }}

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -151,8 +151,8 @@ data:
             salt_length: {{ $auth.file.password.pbkdf2.salt_length | default 16 }}
           sha2crypt:
             variant: {{ $auth.file.password.sha2crypt.variant | default "sha512" | squote }}
-            iterations: {{ $auth.file.password.iterations | default $auth.file.password.sha2crypt.iterations | default "sha512" | squote }}
-            salt_length: {{ $auth.file.password.salt_length | default $auth.file.password.sha2crypt.salt_length | default 16 }}
+            iterations: {{ $auth.file.password.sha2crypt.iterations | default 50000 }}
+            salt_length: {{ $auth.file.password.sha2crypt.salt_length | default 16 }}
           bcrypt:
             variant: {{ $auth.file.password.bcrypt.variant | default "standard" | squote }}
             cost: {{ $auth.file.password.bcrypt.cost | default 12 }}

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -151,7 +151,7 @@ data:
             salt_length: {{ $auth.file.password.pbkdf2.salt_length | default 16 }}
           sha2crypt:
             variant: {{ $auth.file.password.sha2crypt.variant | default "sha512" | squote }}
-            iterations: {{ $auth.file.password.iterations | $auth.file.password.sha2crypt.iterations | default 50000 }}
+            iterations: {{ $auth.file.password.iterations | default $auth.file.password.sha2crypt.iterations | default 50000 }}
             salt_length: {{ $auth.file.password.salt_length | default $auth.file.password.sha2crypt.salt_length | default 16 }}
           bcrypt:
             variant: {{ $auth.file.password.bcrypt.variant | default "standard" | squote }}

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -151,7 +151,7 @@ data:
             salt_length: {{ $auth.file.password.pbkdf2.salt_length | default 16 }}
           sha2crypt:
             variant: {{ $auth.file.password.sha2crypt.variant | default "sha512" | squote }}
-            iterations: {{ $auth.file.password.sha2crypt.iterations | default 50000 }}
+            iterations: {{ $auth.file.password.iterations | $auth.file.password.sha2crypt.iterations | default 50000 }}
             salt_length: {{ $auth.file.password.salt_length | default $auth.file.password.sha2crypt.salt_length | default 16 }}
           bcrypt:
             variant: {{ $auth.file.password.bcrypt.variant | default "standard" | squote }}


### PR DESCRIPTION
Related to this startup error:

```
time="2022-11-20T15:48:18Z" level=error msg="Configuration: authentication_backend: file: password: sha2crypt: option 'iterations' is configured as '3' but must be greater than or equal to '1000'"
time="2022-11-20T15:48:18Z" level=fatal msg="Can't continue due to the errors loading the configuration"

Process finished with exit code 0
```

My `values.yaml` does not configure `sha2crypt`. The chart is rendering a default value for this section of 3 because it is pulling from the `values.yaml` incorrectly and quoting it. The value should make sense for the algorithm and it should not be quoted.

for reference:
https://www.authelia.com/reference/cli/authelia/authelia_crypto_hash_generate_sha2crypt/