### PR TITLE
fix(authelia): oidc secret data not decoded correctly

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.52
+version: 0.8.53
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -36,7 +36,7 @@ data:
     {{- .Values.secret.duo.key | nindent 2 }}: {{ .Values.secret.duo.value | b64enc }}
     {{- end }}
     {{- if .Values.configMap.identity_providers.oidc.enabled }}
-    {{- .Values.secret.oidcHMACSecret.key | nindent 2}}: {{ default (randAlphaNum 32) (default (get $secretData .Values.secret.oidcHMACSecret.key) .Values.secret.oidcHMACSecret.value) | b64enc }}
-    {{- .Values.secret.oidcPrivateKey.key | nindent 2}}: {{ default (genPrivateKey "rsa") (default (get $secretData .Values.secret.oidcPrivateKey.key) .Values.secret.oidcPrivateKey.value) | b64enc }}
+    {{- .Values.secret.oidcHMACSecret.key | nindent 2}}: {{ .Values.secret.oidcHMACSecret.value | default (get $secretData .Values.secret.oidcHMACSecret.key | b64dec) | default (randAlphaNum 32) | b64enc }}
+    {{- .Values.secret.oidcPrivateKey.key | nindent 2}}: {{ .Values.secret.oidcPrivateKey.value | default (get $secretData .Values.secret.oidcPrivateKey.key | b64dec) | default (genPrivateKey "rsa") | b64enc }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
This fixes an issue where the secret data for OpenID Connect 1.0 HMAC Secret and RSA Private Key are not appropriately base64 decoded, and get encoded for a second time.

Fixes #177