### PR TITLE
Add basic auto middleware

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.53
+version: 0.8.54
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -580,6 +580,24 @@ Returns the forwardAuth url
 {{- end -}}
 
 {{/*
+Returns the forwardAuth url
+*/}}
+{{- define "authelia.forwardAuthBasicPath" -}}
+    {{- $scheme := "http" -}}
+    {{- $host := printf "%s.%s" (include "authelia.name" .) .Release.Namespace -}}
+    {{- $cluster := "cluster.local" -}}
+    {{- if .Namespace -}}
+        {{- $host = printf "%s.%s" $host .Namespace -}}
+    {{- end -}}
+    {{- if .Cluster -}}
+        {{- $cluster := .Cluster -}}
+    {{- end -}}
+    {{- $path := (include "authelia.path" .) | trimSuffix "/" -}}
+    {{- $redirect := (include "authelia.ingressHostWithPath" .) -}}
+    {{- (printf "%s://%s.svc.%s%s/api/verify?auth=basic" $scheme $host $cluster $path) -}}
+{{- end -}}
+
+{{/*
 Returns true if we should generate a ConfigMap.
 */}}
 {{- define "authelia.generate.configMap" -}}

--- a/charts/authelia/templates/traefikCRD/middlewares.yaml
+++ b/charts/authelia/templates/traefikCRD/middlewares.yaml
@@ -19,6 +19,22 @@ spec:
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware
 metadata:
+  name: {{ include "authelia.ingress.traefikCRD.middleware.name.forwardAuth" . }}-basic
+  labels: {{ include "authelia.labels" . | nindent 4 }}
+  {{- with $annotations := include "authelia.annotations" . }}
+  annotations: {{ $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  forwardAuth:
+    address: {{ (include "authelia.forwardAuthBasicPath" .) }}
+    trustForwardHeader: true
+    {{- with .Values.ingress.traefikCRD.middlewares.auth.authResponseHeaders }}
+    authResponseHeaders: {{- toYaml . | nindent 6 }}
+  {{- end }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
   name: {{ printf "headers-%s" (include "authelia.name" .) }}
   labels: {{ include "authelia.labels" . | nindent 4 }}
   {{- with $annotations := include "authelia.annotations" . }}
@@ -47,6 +63,26 @@ spec:
       {{- toYaml $middlewares | nindent 6 }}
       {{- end }}
       - name: {{ include "authelia.ingress.traefikCRD.middleware.name.forwardAuth" . }}
+        namespace: {{ .Release.Namespace }}
+  {{- with $middlewares := .Values.ingress.traefikCRD.middlewares.chains.auth.after }}
+  {{- toYaml $middlewares | nindent 6 }}
+  {{- end }}
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "authelia.ingress.traefikCRD.middleware.name.chainAuth" . }}-basic
+  labels: {{ include "authelia.labels" . | nindent 4 }}
+  {{- with $annotations := include "authelia.annotations" . }}
+  annotations: {{ $annotations | nindent 4 }}
+  {{- end }}
+spec:
+  chain:
+    middlewares:
+      {{- with $middlewares := .Values.ingress.traefikCRD.middlewares.chains.auth.before }}
+      {{- toYaml $middlewares | nindent 6 }}
+      {{- end }}
+      - name: {{ include "authelia.ingress.traefikCRD.middleware.name.forwardAuth" . }}-basic
         namespace: {{ .Release.Namespace }}
   {{- with $middlewares := .Values.ingress.traefikCRD.middlewares.chains.auth.after }}
   {{- toYaml $middlewares | nindent 6 }}


### PR DESCRIPTION
Authelia supports basic authentication with forwardauth (/api/verify?auth=basic), but the chart currently only provides middleware for form based authentication (/api/verify?rd=).

This PR adds two middlewares (which both mirrors the existing middlewares):
- forwardauth-*-basic
- chain-*-auth-basic