### PR TITLE
fix: use session.redis.database_index in ConfigMap

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.53
+version: 0.8.54
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -252,6 +252,7 @@ data:
         {{- if not (eq $session.redis.username "") }}
         username: {{ $session.redis.username }}
         {{- end }}
+        database_index: {{ $session.redis.database_index | default 0 }}
         maximum_active_connections: {{ $session.redis.maximum_active_connections | default 8 }}
         minimum_idle_connections: {{ $session.redis.minimum_idle_connections | default 0 }}
         {{- if $session.redis.tls.enabled }}


### PR DESCRIPTION
`configMap.session.redis.database_index` was specified in the `values.yaml` file, but its value was never used. This PR fixes that