### PR TITLE
Allow the specification of a persistent volume name

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.55
+version: 0.8.56
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/persistentVolumeClaim.yaml
+++ b/charts/authelia/templates/persistentVolumeClaim.yaml
@@ -18,5 +18,8 @@ spec:
       storage: {{ default "100Mi" .Values.persistence.size }}
   {{- with $selector := .Values.persistence.selector }}
   selector: {{ toYaml $selector | nindent 4 }}
+  {{- if .Values.persistence.volumeName }}
+  volumeName: "{{ .Values.persistence.volumeName }}"
+  {{- end -}}
   {{- end }}
   {{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -1706,6 +1706,11 @@ persistence:
   storageClass: ""
   # storageClass: "my-storage-class"
 
+  ## Persistent Volume Name
+  ## Useful if Persistent Volumes have been provisioned in advance and you want to use a specific one
+  ##
+  volumeName: ""
+
   accessModes:
     - ReadWriteOnce
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1703,6 +1703,11 @@ persistence:
   storageClass: ""
   # storageClass: "my-storage-class"
 
+  ## Persistent Volume Name
+  ## Useful if Persistent Volumes have been provisioned in advance and you want to use a specific one
+  ##
+  volumeName: ""
+
   accessModes:
   - ReadWriteOnce
 


### PR DESCRIPTION
Hey!

For some usecases it is useful to specify a volumeName in the PVC. I for example run k8s on baremetal and use pre-created iSCSI targets as persistent volumes. Being able to specify those volume names directly would be very useful.

This shouldn't interfere with anything else as long as it is not set. Let me know what you think.