### PR TITLE
feat: add support for custom `initContainers`

### DIFF
--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -81,6 +81,7 @@ This documents the parameters in the chart values. As the chart values are quite
 |pod.kind                                 |Configures the kind of pod: StatefulSet, Deployment, DaemonSet|DaemonSet  |
 |pod.annotations                          |Adds annotations specifically to the pod               |{}                |
 |pod.labels                               |Adds labels specifically to the pod                    |{}                |
+|pod.initContainers                       |Adds additional init containers specifically to the pod|[]                |
 |pod.replicas                             |Configures the replicas for Deployment's/statefulSet's |1                 |
 |pod.revisionHistoryLimit                 |Configures the revisionHistoryLimit                    |1                 |
 |pod.strategy.type                        |Configures the pods strategy/updateStrategy type       |RollingUpdate     |

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -844,6 +844,19 @@ Renders a probe
 {{- end -}}
 
 {{/*
+Renders a value that contains template.
+Usage:
+{{ include "authelia.snippets.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "authelia.snippets.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+{{/*
 Returns the service port.
 */}}
 {{- define "authelia.service.port" -}}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -89,6 +89,9 @@ spec:
       {{- else }}
       enableServiceLinks: false
       {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "authelia.snippets.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       containers:
       - name: authelia
         image: {{ include "authelia.image" . }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -89,8 +89,8 @@ spec:
       {{- else }}
       enableServiceLinks: false
       {{- end }}
-      {{- if .Values.initContainers }}
-      initContainers: {{- include "authelia.snippets.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- if .Values.pod.initContainers }}
+      initContainers: {{- include "authelia.snippets.render" (dict "value" .Values.pod.initContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
       - name: authelia

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -223,6 +223,12 @@ pod:
   # labels:
   #   myLabel: myValue
 
+  initContainers: []
+  # initContainers:
+  # - name: myapp-init
+  #   image: busybox:1.36
+  #   command: ['sh', '-c', 'echo The app is starting! && sleep 5']
+
   replicas: 1
   revisionHistoryLimit: 5
   priorityClassName: ""

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -221,6 +221,12 @@ pod:
   # labels:
   #   myLabel: myValue
 
+  initContainers: []
+  # initContainers:
+  # - name: myapp-init
+  #   image: busybox:1.36
+  #   command: ['sh', '-c', 'echo The app is starting! && sleep 5']
+
   replicas: 1
   revisionHistoryLimit: 5
   priorityClassName: ""


### PR DESCRIPTION
# Description                                                                                  
                                                                    
Adding custom initialization containers gives users more fine-grained control over their deployments. Adding custom `initContainers` is possible in [Bitnami charts](https://github.com/search?q=repo%3Abitnami%2Fcharts%20initcontainers&type=code) as well.
                                                                                               
One example use-case is [ensuring that another service is available](https://medium.com/@xcoulon/initializing-containers-in-order-with-kubernetes-18173b9cc222).

## TODO

- [ ] Add unit tests