### PR TITLE
feat: allow to user NodePort type for service

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.57
+version: 0.8.58
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/service.yaml
+++ b/charts/authelia/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations: {{ $annotations | nindent 4 }}
   {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type | quote }}
   {{- with $ip := .Values.service.clusterIP }}
   clusterIP: {{ $ip }}
   {{- end }}
@@ -22,6 +22,7 @@ spec:
       protocol: TCP
       port: {{ include "authelia.service.port" . }}
       targetPort: http
+      nodePort: {{ .Values.service.nodePort }}
     {{- if and (semverCompare ">=4.36.0" (include "authelia.version" .)) .Values.configMap.telemetry.metrics.enabled }}
     - name: metrics
       protocol: TCP

--- a/charts/authelia/templates/service.yaml
+++ b/charts/authelia/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations: {{ $annotations | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type | quote }}
+  type: {{ .Values.service.type }}
   {{- with $ip := .Values.service.clusterIP }}
   clusterIP: {{ $ip }}
   {{- end }}

--- a/charts/authelia/templates/service.yaml
+++ b/charts/authelia/templates/service.yaml
@@ -22,7 +22,9 @@ spec:
       protocol: TCP
       port: {{ include "authelia.service.port" . }}
       targetPort: http
+      {{- if eq .Values.service.type "NodePort" }}
       nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
     {{- if and (semverCompare ">=4.36.0" (include "authelia.version" .)) .Values.configMap.telemetry.metrics.enabled }}
     - name: metrics
       protocol: TCP

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -88,7 +88,7 @@ service:
   #   myLabel: myValue
 
   port: 80
-  nodePort: 9091
+  nodePort: 30091
   
   # clusterIP:
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -89,7 +89,6 @@ service:
 
   port: 80
   nodePort: 30091
-  
   # clusterIP:
 
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -78,6 +78,7 @@ rbac:
 domain: example.com
 
 service:
+  type: "ClusterIP"
   annotations: {}
   # annotations:
   #   myAnnotation: myValue
@@ -87,7 +88,6 @@ service:
   #   myLabel: myValue
 
   port: 80
-
   # clusterIP:
 
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -88,6 +88,8 @@ service:
   #   myLabel: myValue
 
   port: 80
+  nodePort: 9091
+  
   # clusterIP:
 
 


### PR DESCRIPTION
Hello,

This MR allows to change the type service with `NodePort` if needed. By default, the behaviour is not changed.

My use case is that for Traefik Middleware, I need to reach Authelia internally but my Traefik instance is out of the cluster. So I required the service to be exposed by the NodePort.