### PR TITLE
feat: add support for new traefik apiVersion

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.58
+version: 0.8.59
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_capabilities.tpl
+++ b/charts/authelia/templates/_capabilities.tpl
@@ -127,3 +127,14 @@ PodDisruptionBudget API Version Releases: policy/v1 in 1.21, policy/v1beta1 prio
         {{- print "policy/v1beta1" -}}
     {{- end }}
 {{- end -}}
+
+{{/*
+Returns applicable traefikCRD API version
+*/}}
+{{- define "capabilities.apiVersion.traefikCRD" -}}
+    {{- if .Capabilities.APIVersions.Has "traefik.io/v1alpha1" -}}
+        {{- print "traefik.io/v1alpha1" -}}
+    {{- else -}}
+        {{- print "traefik.containo.us/v1alpha1" -}}
+    {{- end }}
+{{- end -}}

--- a/charts/authelia/templates/traefikCRD/ingressRoute.yaml
+++ b/charts/authelia/templates/traefikCRD/ingressRoute.yaml
@@ -1,6 +1,6 @@
 {{ if (include "authelia.enabled.ingress.ingressRoute" .) -}}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "capabilities.apiVersion.traefikCRD" . }}
 kind: IngressRoute
 metadata:
   name: {{ include "authelia.name" . }}

--- a/charts/authelia/templates/traefikCRD/middlewares.yaml
+++ b/charts/authelia/templates/traefikCRD/middlewares.yaml
@@ -1,6 +1,6 @@
 {{ if (include "authelia.enabled.ingress.traefik" .) -}}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "capabilities.apiVersion.traefikCRD" . }}
 kind: Middleware
 metadata:
   name: {{ include "authelia.ingress.traefikCRD.middleware.name.forwardAuth" . }}
@@ -16,7 +16,7 @@ spec:
     authResponseHeaders: {{- toYaml . | nindent 6 }}
   {{- end }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "capabilities.apiVersion.traefikCRD" . }}
 kind: Middleware
 metadata:
   name: {{ printf "headers-%s" (include "authelia.name" .) }}
@@ -32,7 +32,7 @@ spec:
       Cache-Control: "no-store"
       Pragma: "no-cache"
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "capabilities.apiVersion.traefikCRD" . }}
 kind: Middleware
 metadata:
   name: {{ include "authelia.ingress.traefikCRD.middleware.name.chainAuth" . }}
@@ -52,7 +52,7 @@ spec:
   {{- toYaml $middlewares | nindent 6 }}
   {{- end }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "capabilities.apiVersion.traefikCRD" . }}
 kind: Middleware
 metadata:
   name: {{ include "authelia.ingress.traefikCRD.middleware.name.chainIngress" . }}

--- a/charts/authelia/templates/traefikCRD/tlsOption.yaml
+++ b/charts/authelia/templates/traefikCRD/tlsOption.yaml
@@ -1,5 +1,5 @@
 {{ if (include "authelia.enabled.ingress.traefik.tlsOption" .) -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "capabilities.apiVersion.traefikCRD" . }}
 kind: TLSOption
 metadata:
   name: {{ .Values.ingress.traefikCRD.tls.options.nameOverride | default (include "authelia.name" .) }}


### PR DESCRIPTION
Use the new traefik apiVersion if it is available.

Does a simple capabilities check against the cluster and selects the traefik.io/v1alpha1 apiVersion if it exists, otherwise falls back to traefik.containo.us/v1alpha1