### PR TITLE
feat: Allows user to specify traefikCRD apiVersion (to support Traefik v3)

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.8.58
+version: 0.8.59
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_capabilities.tpl
+++ b/charts/authelia/templates/_capabilities.tpl
@@ -127,3 +127,14 @@ PodDisruptionBudget API Version Releases: policy/v1 in 1.21, policy/v1beta1 prio
         {{- print "policy/v1beta1" -}}
     {{- end }}
 {{- end -}}
+
+{{/*
+Returns applicable TraefikCRD apiVersion
+*/}}
+{{- define "capabilities.apiVersion.traefikCRD" -}}
+    {{- if .Capabilities.APIVersions.Has "traefik.io/v1alpha1" -}}
+        {{- print "traefik.io/v1alpha1" -}}
+    {{- else -}}
+        {{- print "traefik.containo.us/v1alpha1" -}}
+    {{- end }}
+{{- end -}}

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -43,6 +43,17 @@ Return the app version.
 {{- end -}}
 
 {{/*
+Returns the traefikCRD apiVersion
+*/}}
+{{- define "authelia.ingress.traefikCRD.apiVersion" -}}
+    {{- if .Values.ingress.traefikCRD.apiVersion -}}
+        {{- .Values.ingress.traefikCRD.apiVersion -}}
+    {{- else -}}
+        {{- include "capabilities.apiVersion.traefikCRD" . -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
 Returns the name of the forwardAuth Middleware for forward auth which gets applied to other IngressRoutes.
 */}}
 {{- define "authelia.ingress.traefikCRD.middleware.name.forwardAuth" -}}

--- a/charts/authelia/templates/traefikCRD/ingressRoute.yaml
+++ b/charts/authelia/templates/traefikCRD/ingressRoute.yaml
@@ -1,6 +1,6 @@
 {{ if (include "authelia.enabled.ingress.ingressRoute" .) -}}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "authelia.ingress.traefikCRD.apiVersion" . }}
 kind: IngressRoute
 metadata:
   name: {{ include "authelia.name" . }}

--- a/charts/authelia/templates/traefikCRD/middlewares.yaml
+++ b/charts/authelia/templates/traefikCRD/middlewares.yaml
@@ -1,6 +1,6 @@
 {{ if (include "authelia.enabled.ingress.traefik" .) -}}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "authelia.ingress.traefikCRD.apiVersion" . }}
 kind: Middleware
 metadata:
   name: {{ include "authelia.ingress.traefikCRD.middleware.name.forwardAuth" . }}
@@ -16,7 +16,7 @@ spec:
     authResponseHeaders: {{- toYaml . | nindent 6 }}
   {{- end }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "authelia.ingress.traefikCRD.apiVersion" . }}
 kind: Middleware
 metadata:
   name: {{ printf "headers-%s" (include "authelia.name" .) }}
@@ -32,7 +32,7 @@ spec:
       Cache-Control: "no-store"
       Pragma: "no-cache"
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "authelia.ingress.traefikCRD.apiVersion" . }}
 kind: Middleware
 metadata:
   name: {{ include "authelia.ingress.traefikCRD.middleware.name.chainAuth" . }}
@@ -52,7 +52,7 @@ spec:
   {{- toYaml $middlewares | nindent 6 }}
   {{- end }}
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "authelia.ingress.traefikCRD.apiVersion" . }}
 kind: Middleware
 metadata:
   name: {{ include "authelia.ingress.traefikCRD.middleware.name.chainIngress" . }}

--- a/charts/authelia/templates/traefikCRD/tlsOption.yaml
+++ b/charts/authelia/templates/traefikCRD/tlsOption.yaml
@@ -1,5 +1,5 @@
 {{ if (include "authelia.enabled.ingress.traefik.tlsOption" .) -}}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: {{ include "authelia.ingress.traefikCRD.apiVersion" . }}
 kind: TLSOption
 metadata:
   name: {{ .Values.ingress.traefikCRD.tls.options.nameOverride | default (include "authelia.name" .) }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -125,6 +125,10 @@ ingress:
   traefikCRD:
     enabled: false
 
+    ## The TraefikCRD apiVersion to use. traefik.containo.us/v1alpha1 is the default but is deprecated since Traefik 2.10 and removed in Traevik v3.
+    # apiVersion: traefik.io/v1alpha1
+    apiVersion: traefik.containo.us/v1alpha1
+
     ## Use a standard Ingress object, not an IngressRoute.
     disableIngressRoute: false
 

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -126,6 +126,7 @@ ingress:
     enabled: false
 
     ## The TraefikCRD apiVersion to use. traefik.containo.us/v1alpha1 is the default but is deprecated since Traefik 2.10 and removed in Traevik v3.
+    ## Setting this value to null chooses traefik.io/v1alpha1 if it is supported by the cluster
     # apiVersion: traefik.io/v1alpha1
     apiVersion: traefik.containo.us/v1alpha1
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -124,6 +124,10 @@ ingress:
   traefikCRD:
     enabled: false
 
+    ## The TraefikCRD apiVersion to use. traefik.containo.us/v1alpha1 is the default but is deprecated since Traefik 2.10 and removed in Traevik v3.
+    # apiVersion: traefik.io/v1alpha1
+    apiVersion: traefik.containo.us/v1alpha1
+
     ## Use a standard Ingress object, not an IngressRoute.
     disableIngressRoute: false
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -125,6 +125,7 @@ ingress:
     enabled: false
 
     ## The TraefikCRD apiVersion to use. traefik.containo.us/v1alpha1 is the default but is deprecated since Traefik 2.10 and removed in Traevik v3.
+    ## Setting this value to null chooses traefik.io/v1alpha1 if it is supported by the cluster
     # apiVersion: traefik.io/v1alpha1
     apiVersion: traefik.containo.us/v1alpha1
 


### PR DESCRIPTION
Defaults to traefik.containo.us/v1alpha1, but allows user to specify traefik.io/v1alpha1 if they are using a newer version of traefik by setting the ingress.traefikCRD.apiVersion value in values.yaml or setting it to null which will choose the apiVersion based on the cluster capabilities.

traefik.containo.us/v1alpha1 is deprecated in Traefik 2.10 and removed in Traefik v3 in favor of traefik.io/v1alpha1
