### PR TITLE
Add support for integrated Redis

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.1
+version: 0.9.0
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.0
+version: 0.9.1
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -29,6 +29,10 @@ dependencies:
     version: ~17.0.1
     repository: https://charts.bitnami.com/bitnami
     condition: storage.mysql.deploy
+  - name: redis
+    version: ~19.0.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: session.redis.deploy
 maintainers:
   - name: james-d-elliott
     email: james-d-elliott@users.noreply.github.com

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -4,9 +4,8 @@
 not recommended at this stage for production environments without manual intervention to check the templated manifests
 match your desired state.
 
-This chart uses api version 2 which is only supported by helm v3+. This is a ***standalone*** chart intended just to
-deploy *Authelia* on its own. Eventually we may publish an `authelia-bundle` chart which includes `redis` and
-`postgresql`.
+This chart uses api version 2 which is only supported by helm v3+. This chart includes Bitnami subcharts to optionally
+deploy `redis`, `postgresql` and/or `mariadb`.
 
 # Breaking Changes
 
@@ -153,6 +152,7 @@ values.yaml is based on the *Authelia* configuration. See the
 |      configMap.authentication_backend.ldap.enabled      |       Enables LDAP auth when generating the config       |        true        |
 |      configMap.authentication_backend.file.enabled      |       Enables file auth when generating the config       |       false        |
 |             configMap.session.redis.enabled             | Enables redis session storage when generating the config |        true        |
+|             configMap.session.redis.deploy              |                 Deploy a redis instance                  |       false        |
 |          configMap.session.redis.enabledSecret          |    Forces redis password auth using a secret if true     |       false        |
 |    configMap.session.redis.high_availability.enabled    |    Enables redis sentinel when generating the config     |       false        |
 | configMap.session.redis.high_availability.enabledSecret |   Forces sentinel password auth using a secret if true   |       false        |
@@ -165,6 +165,9 @@ values.yaml is based on the *Authelia* configuration. See the
 |             configMap.notifier.smtp.enabled             |          Enables the SMTP notification provider          |        true        |
 |          configMap.notifier.smtp.enabledSecret          |     Forces smtp password auth using a secret if true     |       false        |
 |        configMap.identity_providers.oidc.enabled        |              Enables the OpenID Connect Idp              |       false        |
+
+If any of `configMap.session.redis.deploy`, `configMap.storage.mysql.deploy` or `configMap.storage.postgres.deploy` are
+enabled, the corresponding top-level `redis`, `mariadb` or `postgresql` sections must be configured.
 
 ## Secret
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1146,6 +1146,7 @@ configMap:
     ## The redis connection details
     redis:
       enabled: false
+      deploy: false
       enabledSecret: false
       host: 'redis.databases.svc.cluster.local'
       port: 6379
@@ -1880,3 +1881,36 @@ postgresql:
       # storageClass: ""
       size: 1Gi
     resources: {}
+
+# -- Configure redis database subchart under this key.
+#    This will be deployed when session.redis.deploy is set to true
+#    Currently settings need to be manually copied from here to the session.redis section
+#    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+redis:
+  architecture: standalone
+  auth:
+    enabled: false
+    sentinel: true
+    password: "redis"
+    existingSecret: ""
+    existingSecretPasswordKey: ""
+    usePasswordFiles: false
+  master:
+    resources: {}
+    priorityClassName: ""
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+  replica:
+    replicaCount: 3
+    resources: {}
+    priorityClassName: ""
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi


### PR DESCRIPTION
This PR is exactly the same as #223, but adds Redis support from Bitnami helm charts, along with the existing MariaDB and PostgreSQL support.

Existing behaviour is retained - users have to opt in to deploying Redis.

This finally fixes #89 and #172