### PR TITLE
fix: multiple issues

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.0-beta2
+version: 0.9.0-beta3
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_oidc.tpl
+++ b/charts/authelia/templates/_oidc.tpl
@@ -14,9 +14,11 @@ Returns the OpenID Connect 1.0 clients token endpoint authentication method.
 Returns the OpenID Connect 1.0 clients secret.
 */}}
 {{- define "authelia.config.oidc.client.client_secret" -}}
-    {{- if or .public (and (not .client_secret) (not .client_secret.value) (not .client_secret.path)) }}
+    {{- if .public }}
         {{- "" }}
-    {{- else if hasKey .client_secret "value" }}
+    {{- else if kindIs "string" .client_secret }}
+        {{- .client_secret }}
+    {{- else if and (kindIs "map" .client_secret) (hasKey .client_secret "value") }}
         {{- .client_secret.value }}
     {{- end }}
 {{- end }}
@@ -26,7 +28,7 @@ Returns the OpenID Connect 1.0 clients secret.
         {{- if and (not (kindIs "string" .client_secret)) .client_secret.path }}
             {{- printf "'{{ secret \"%s\" }}'" .client_secret.path }}
         {{- else }}
-            {{- (include "authelia.config.oidc.client.client_secret.value" .) | squote }}
+            {{- (include "authelia.config.oidc.client.client_secret" .) | squote }}
         {{- end }}
     {{- end }}
 {{- end -}}

--- a/charts/authelia/templates/traefikCRD/ingressRoute.yaml
+++ b/charts/authelia/templates/traefikCRD/ingressRoute.yaml
@@ -35,14 +35,14 @@ spec:
         weight: {{ $.Values.ingress.traefikCRD.weight | default 10 }}
         responseForwarding:
           flushInterval: {{ $.Values.ingress.traefikCRD.responseForwardingFlushInterval | default "100ms" }}
-      {{- if $.Values.ingress.traefikCRD.sticky }}
-      sticky:
-        cookie:
-          httpOnly: true
-          name: {{ $.Values.ingress.traefikCRD.stickyCookieNameOverride | default (printf "%s_traefik_lb" (include "authelia.name" $)) }}
-          secure: true
-          sameSite: None
-    {{- end }}
+        {{- if $.Values.ingress.traefikCRD.sticky }}
+        sticky:
+          cookie:
+            httpOnly: true
+            name: {{ $.Values.ingress.traefikCRD.stickyCookieNameOverride | default (printf "%s_traefik_lb" (include "authelia.name" $)) }}
+            secure: true
+            sameSite: None
+        {{- end }}
   {{- end }}
   {{- else }}
   {{- range $cookie := .Values.configMap.session.cookies }}
@@ -63,14 +63,14 @@ spec:
         weight: {{ $.Values.ingress.traefikCRD.weight | default 10 }}
         responseForwarding:
           flushInterval: {{ $.Values.ingress.traefikCRD.responseForwardingFlushInterval | default "100ms" }}
-      {{- if $.Values.ingress.traefikCRD.sticky }}
-      sticky:
-        cookie:
-          httpOnly: true
-          name: {{ $.Values.ingress.traefikCRD.stickyCookieNameOverride | default (printf "%s_traefik_lb" (include "authelia.name" $)) }}
-          secure: true
-          sameSite: None
-      {{- end }}
+        {{- if $.Values.ingress.traefikCRD.sticky }}
+        sticky:
+          cookie:
+            httpOnly: true
+            name: {{ $.Values.ingress.traefikCRD.stickyCookieNameOverride | default (printf "%s_traefik_lb" (include "authelia.name" $)) }}
+            secure: true
+            sameSite: None
+        {{- end }}
   {{- end }}
   {{- end }}
   {{- if .Values.ingress.tls.enabled }}


### PR DESCRIPTION
This fixes an issue where the client secret would not properly be rendered when included as a raw value. This also fixes an issue where the sticky service value for Traefik was not correctly indented.