### PR TITLE
Fix `session.remember_me` using `inactivity` value

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.0-beta3
+version: 0.9.0-beta4
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -198,7 +198,7 @@ data:
       same_site: {{ $session.same_site | default "lax" | squote }}
       inactivity: {{ include "authelia.func.dquote" ($session.inactivity | default "5 minutes") }}
       expiration: {{ include "authelia.func.dquote" ($session.expiration | default "1 hour") }}
-      remember_me: {{ include "authelia.func.dquote" ($session.inactivity | default "1 month") }}
+      remember_me: {{ include "authelia.func.dquote" ($session.remember_me | default "1 month") }}
       cookies:
       {{- range $cookie := (required "The value 'configMap.session.cookies' must have at least one configuration" $session.cookies) }}
         - domain: {{ required "All 'domain' values for the 'configMap.session.cookies' configurations must be configured" .domain | squote }}


### PR DESCRIPTION
This seems to be a regression with the 0.9.0 version, introduced in [the 4.38.0 update commit](https://github.com/authelia/chartrepo/blame/9fccf91dbbd19ca183f7edb1ce7a8f252c1a8335/charts/authelia/templates/configMap.yaml#L201).
Quite annoying because `inactivity` is `5 minutes` by default, leading to constant logouts.

~~I am currently targeting `0.9.0-beta3`, but I'd assume this is incorrect. Unfortunately, I couldn't find a branch for new `0.9.0` releases, please let me know which one to use and I can open a new PR.~~
~~I just noticed that 0.9 betas are actually on `master`. Hence, I've changed the base accordingly. I'll have to rebase my commits onto it tomorrow which should *hopefully* remove the extra commits there and allow a clean merge.~~