### PR TITLE
[WIP] Bundle Helm charts for Redis, MariaDB and PostgreSQL

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -17,3 +17,19 @@ if [[ "${BUILDKITE_STEP_KEY}" == "upload" ]] || [[ "${BUILDKITE_STEP_KEY}" == "i
 
   buildkite-agent artifact download .cr-release-packages/* .cr-release-packages
 fi
+
+
+if [[ "${BUILDKITE_STEP_KEY}" == "package" ]] || [[ "${BUILDKITE_STEP_KEY}" == "package-test" ]]; then
+  echo "--- :testobject: Adding Bitnami Chart Repo"
+
+  helm repo add bitnami https://charts.bitnami.com/bitnami
+fi
+
+if [[ "${BUILDKITE_STEP_KEY}" == "package" ]] || [[ "${BUILDKITE_STEP_KEY}" == "package-test" ]]; then
+  echo "--- :lock: Updating and Locking Dependencies"
+
+  ct --config .buildkite/ct.yaml list-changed --since HEAD~1 | xargs -n1 helm dependency build
+
+  ls charts/authelia/charts -al
+  ls charts -al
+fi

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -16,7 +16,7 @@ steps:
     charts: "true"
   if: build.branch != "gh-pages" && build.env("CHART_CHANGES") == "true"
 
-- command: "ct --config .buildkite/ct.yaml list-changed --since HEAD~1 | xargs -n1 cr --config .buildkite/cr.yaml package"
+- command: "ct --config .buildkite/ct.yaml list-changed --since HEAD~1 | xargs -n1 helm package"
   key: "package-test"
   label: ":package: Package Chart (Chart Releaser)"
   artifact_paths:
@@ -29,7 +29,7 @@ steps:
   continue_on_failure: true
   if: build.branch == "master" && build.env("CHART_CHANGES") == "true"
 
-- command: "ct --config .buildkite/ct.yaml list-changed --since HEAD~1 | xargs -n1 cr --config .buildkite/cr.yaml package"
+- command: "ct --config .buildkite/ct.yaml list-changed --since HEAD~1 | xargs -n1 helm package"
   key: "package"
   label: ":package: Package Chart (Chart Releaser)"
   artifact_paths:

--- a/charts/authelia/.helmignore
+++ b/charts/authelia/.helmignore
@@ -6,7 +6,6 @@
 .idea
 *.tmproj
 *.png
-*.tgz
 docs/
 screenshots/
 scripts/

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -29,6 +29,10 @@ dependencies:
     version: ~17.0.1
     repository: https://charts.bitnami.com/bitnami
     condition: storage.mysql.deploy
+  - name: redis
+    version: ~19.0.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: session.redis.deploy
 maintainers:
   - name: james-d-elliott
     email: james-d-elliott@users.noreply.github.com

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -20,7 +20,15 @@ home: https://www.authelia.com
 sources:
   - https://github.com/authelia/chartrepo/tree/master/charts/authelia
   - https://www.github.com/authelia/authelia
-dependencies: []
+dependencies:
+  - name: postgresql
+    version: ~15.1.4
+    repository: https://charts.bitnami.com/bitnami
+    condition: storage.postgres.deploy
+  - name: mariadb
+    version: ~17.0.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: storage.mysql.deploy
 maintainers:
   - name: james-d-elliott
     email: james-d-elliott@users.noreply.github.com

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.0-beta5
+version: 0.10.0-beta1
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -144,27 +144,29 @@ This section only documents the sections that are specific to the helm chart. Th
 values.yaml is based on the *Authelia* configuration. See the
 [Authelia documentation](https://www.authelia.com/configuration) for more information.
 
-|                        Parameter                        |                       Description                        |      Default       |
-|:-------------------------------------------------------:|:--------------------------------------------------------:|:------------------:|
-|                    configMap.enabled                    |  If true generates the ConfigMap, otherwise it doesn't   |        true        |
-|                  configMap.annotations                  |        Extra annotations to add to the ConfigMap         |         {}         |
-|                    configMap.labels                     |           Extra labels to add to the ConfigMap           |         {}         |
-|                      configMap.key                      |  The key inside the ConfigMap which contains the config  | configuration.yaml |
-|               configMap.existingConfigMap               | Instead of generating a ConfigMap refers to an existing  |        nil         |
-|                configMap.duo_api.enabled                |  Enables the Duo integration when generating the config  |       false        |
-|      configMap.authentication_backend.ldap.enabled      |       Enables LDAP auth when generating the config       |        true        |
-|      configMap.authentication_backend.file.enabled      |       Enables file auth when generating the config       |       false        |
-|             configMap.session.redis.enabled             | Enables redis session storage when generating the config |        true        |
-|          configMap.session.redis.enabledSecret          |    Forces redis password auth using a secret if true     |       false        |
-|    configMap.session.redis.high_availability.enabled    |    Enables redis sentinel when generating the config     |       false        |
-| configMap.session.redis.high_availability.enabledSecret |   Forces sentinel password auth using a secret if true   |       false        |
-|             configMap.storage.local.enabled             |           Enables the SQLite3 storage provider           |       false        |
-|             configMap.storage.mysql.enabled             |            Enables the MySQL storage provider            |       false        |
-|           configMap.storage.postgres.enabled            |         Enables the PostgreSQL storage provider          |        true        |
-|          configMap.notifier.filesystem.enabled          |       Enables the filesystem notification provider       |       false        |
-|             configMap.notifier.smtp.enabled             |          Enables the SMTP notification provider          |        true        |
-|          configMap.notifier.smtp.enabledSecret          |     Forces smtp password auth using a secret if true     |       false        |
-|        configMap.identity_providers.oidc.enabled        |              Enables the OpenID Connect Idp              |       false        |
+|Parameter                                              |Description                                             |Default           |
+|:-----------------------------------------------------:|:------------------------------------------------------:|:----------------:|
+|configMap.enabled                                      |If true generates the ConfigMap, otherwise it doesn't   |true              |
+|configMap.annotations                                  |Extra annotations to add to the ConfigMap               |{}                |
+|configMap.labels                                       |Extra labels to add to the ConfigMap                    |{}                |
+|configMap.key                                          |The key inside the ConfigMap which contains the config  |configuration.yaml|
+|configMap.existingConfigMap                            |Instead of generating a ConfigMap refers to an existing |nil               |
+|configMap.duo_api.enabled                              |Enables the Duo integration when generating the config  |false             |
+|configMap.authentication_backend.ldap.enabled          |Enables LDAP auth when generating the config            |true              |
+|configMap.authentication_backend.file.enabled          |Enables file auth when generating the config            |false             |
+|configMap.session.redis.enabled                        |Enables redis session storage when generating the config|true              |
+|configMap.session.redis.enabledSecret                  |Forces redis password auth using a secret if true       |false             |
+|configMap.session.redis.high_availability.enabled      |Enables redis sentinel when generating the config       |false             |
+| configMap.session.redis.high_availability.enabledSecret | Forces sentinel password auth using a secret if true    |false             |
+|configMap.storage.local.enabled                        |Enables the SQLite3 storage provider                    |false             |
+|configMap.storage.mysql.enabled                        |Enables the MySQL storage provider                      |false             |
+|configMap.storage.mysql.deploy                         |Deploy a MariaDB instance                               |false             |
+|configMap.storage.postgres.enabled                     |Enables the PostgreSQL storage provider                 |true              |
+|configMap.storage.postgres.deploy                      |Deploy a PostgreSQL instance                            |false             |
+|configMap.notifier.filesystem.enabled                  |Enables the filesystem notification provider            |false             |
+|configMap.notifier.smtp.enabled                        |Enables the SMTP notification provider                  |true              |
+|configMap.notifier.smtp.enabledSecret                  |Forces smtp password auth using a secret if true        |false             |
+|configMap.identity_providers.oidc.enabled              |Enables the OpenID Connect Idp                          |false             |
 
 ## Secret
 

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -4,9 +4,8 @@
 not recommended at this stage for production environments without manual intervention to check the templated manifests
 match your desired state.
 
-This chart uses api version 2 which is only supported by helm v3+. This is a ***standalone*** chart intended just to
-deploy *Authelia* on its own. Eventually we may publish an `authelia-bundle` chart which includes `redis` and
-`postgresql`.
+This chart uses api version 2 which is only supported by helm v3+. This chart includes Bitnami subcharts to optionally
+deploy `redis`, `postgresql` and/or `mariadb`.
 
 # Breaking Changes
 
@@ -155,6 +154,7 @@ values.yaml is based on the *Authelia* configuration. See the
 |configMap.authentication_backend.ldap.enabled          |Enables LDAP auth when generating the config            |true              |
 |configMap.authentication_backend.file.enabled          |Enables file auth when generating the config            |false             |
 |configMap.session.redis.enabled                        |Enables redis session storage when generating the config|true              |
+|configMap.session.redis.deploy              |                 Deploy a redis instance                  |       false        |
 |configMap.session.redis.enabledSecret                  |Forces redis password auth using a secret if true       |false             |
 |configMap.session.redis.high_availability.enabled      |Enables redis sentinel when generating the config       |false             |
 | configMap.session.redis.high_availability.enabledSecret | Forces sentinel password auth using a secret if true    |false             |
@@ -167,6 +167,9 @@ values.yaml is based on the *Authelia* configuration. See the
 |configMap.notifier.smtp.enabled                        |Enables the SMTP notification provider                  |true              |
 |configMap.notifier.smtp.enabledSecret                  |Forces smtp password auth using a secret if true        |false             |
 |configMap.identity_providers.oidc.enabled              |Enables the OpenID Connect Idp                          |false             |
+
+If any of `configMap.session.redis.deploy`, `configMap.storage.mysql.deploy` or `configMap.storage.postgres.deploy` are
+enabled, the corresponding top-level `redis`, `mariadb` or `postgresql` sections must be configured.
 
 ## Secret
 

--- a/charts/authelia/templates/validations.secets.check.yaml
+++ b/charts/authelia/templates/validations.secets.check.yaml
@@ -26,14 +26,6 @@
 {{- fail (printf "The secret %s must be configured as one of the additional secrets as it's being used for the 'configMap.storage.encryption_key' secret" .Values.configMap.storage.encryption_key.secret_name) }}
 {{- end }}
 
-{{- if and .Values.configMap.storage.mysql.password.secret_name (not (hasKey .Values.secret.additionalSecrets .Values.configMap.storage.mysql.password.secret_name)) }}
-{{- fail (printf "The secret %s must be configured as one of the additional secrets as it's being used for the 'configMap.storage.mysql.password' secret" .Values.configMap.storage.mysql.password.secret_name) }}
-{{- end }}
-
-{{- if and .Values.configMap.storage.postgres.password.secret_name (not (hasKey .Values.secret.additionalSecrets .Values.configMap.storage.postgres.password.secret_name)) }}
-{{- fail (printf "The secret %s must be configured as one of the additional secrets as it's being used for the 'configMap.storage.postgres.password' secret" .Values.configMap.storage.postgres.password.secret_name) }}
-{{- end }}
-
 {{- if and .Values.configMap.notifier.smtp.password.secret_name (not (hasKey .Values.secret.additionalSecrets .Values.configMap.notifier.smtp.password.secret_name)) }}
 {{- fail (printf "The secret %s must be configured as one of the additional secrets as it's being used for the 'configMap.notifier.smtp.password' secret" .Values.configMap.notifier.smtp.password.secret_name) }}
 {{- end }}

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1154,6 +1154,7 @@ configMap:
     ## The redis connection details
     redis:
       enabled: false
+      deploy: false
       enabledSecret: false
       host: 'redis.databases.svc.cluster.local'
       port: 6379
@@ -1862,3 +1863,36 @@ postgresql:
       # storageClass: ""
       size: 1Gi
     resources: {}
+
+# -- Configure redis database subchart under this key.
+#    This will be deployed when session.redis.deploy is set to true
+#    Currently settings need to be manually copied from here to the session.redis section
+#    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+redis:
+  architecture: standalone
+  auth:
+    enabled: false
+    sentinel: true
+    password: "redis"
+    existingSecret: ""
+    existingSecretPasswordKey: ""
+    usePasswordFiles: false
+  master:
+    resources: {}
+    priorityClassName: ""
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+  replica:
+    replicaCount: 3
+    resources: {}
+    priorityClassName: ""
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1319,6 +1319,7 @@ configMap:
       port: 3306
       database: authelia
       username: authelia
+      password: authelia
       timeout: 5s
       tls:
         enabled: false
@@ -1352,6 +1353,7 @@ configMap:
       database: authelia
       schema: public
       username: authelia
+      password: authelia
       timeout: 5s
       tls:
         enabled: false

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1313,25 +1313,12 @@ configMap:
     ##
     mysql:
       enabled: false
-      address: 'tcp://mysql.databases.svc.cluster.local:3306'
-      timeout: '5 seconds'
-      database: 'authelia'
-      username: 'authelia'
-      password:
-        ## Disables this secret and leaves configuring it entirely up to you.
-        disabled: false
-
-        ## The secret name. The ~ name is special as it is the secret we generate either automatically or via the
-        ## secret_value option below.
-        secret_name: ~
-
-        ## The value of a generated secret when using the ~ secret_name.
-        value: ''
-
-        ## The path to the secret. If it has a '/' prefix it's assumed to be an absolute path within the pod. Otherwise
-        ## it uses the format '{mountPath}/{secret_name}/{path}' where '{mountPath}' refers to the 'secret.mountPath'
-        ## value, '{secret_name}' is the secret_name above, and '{path}' is this value.
-        path: 'storage.mysql.password.txt'
+      deploy: false
+      host: mysql.databases.svc.cluster.local
+      port: 3306
+      database: authelia
+      username: authelia
+      timeout: 5s
       tls:
         enabled: false
 
@@ -1357,27 +1344,14 @@ configMap:
     ## PostgreSQL (Storage Provider)
     ##
     postgres:
-      enabled: false
-      address: 'tcp://postgres.databases.svc.cluster.local:5432'
-      timeout: '5 seconds'
-      database: 'authelia'
-      schema: 'public'
-      username: 'authelia'
-      password:
-        ## Disables this secret and leaves configuring it entirely up to you.
-        disabled: false
-
-        ## The secret name. The ~ name is special as it is the secret we generate either automatically or via the
-        ## secret_value option below.
-        secret_name: ~
-
-        ## The value of a generated secret when using the ~ secret_name.
-        value: ''
-
-        ## The path to the secret. If it has a '/' prefix it's assumed to be an absolute path within the pod. Otherwise
-        ## it uses the format '{mountPath}/{secret_name}/{path}' where '{mountPath}' refers to the 'secret.mountPath'
-        ## value, '{secret_name}' is the secret_name above, and '{path}' is this value.
-        path: 'storage.postgres.password.txt'
+      enabled: true
+      deploy: false
+      host: postgres.databases.svc.cluster.local
+      port: 5432
+      database: authelia
+      schema: public
+      username: authelia
+      timeout: 5s
       tls:
         enabled: false
 
@@ -1853,4 +1827,38 @@ persistence:
   size: '100Mi'
 
   selector: {}
-...
+
+# -- Configure mariadb database subchart under this key.
+#    This will be deployed when storage.mysql.deploy is set to true
+#    Currently settings need to be manually copied from here to the storage.mysql section
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+mariadb:
+  architecture: standalone
+  auth:
+    database: authelia
+    username: authelia
+    password: authelia
+    rootPassword: authelia
+  primary:
+    resources: {}
+    persistence:
+      enabled: false
+      size: 1Gi
+      # storageClass: ""
+
+# -- Configure postgresql database subchart under this key.
+#    This will be deployed when storage.postgres.deploy is set to true
+#    Currently settings need to be manually copied from here to the storage.postgres section
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+postgresql:
+  auth:
+    postgresPassword: authelia
+    username: authelia
+    password: authelia
+    database: authelia
+  primary:
+    persistence:
+      enabled: false
+      # storageClass: ""
+      size: 1Gi
+    resources: {}


### PR DESCRIPTION
This PR adds basic support for deploying Redis, MariaDB or PostgreSQL as part of an Authelia deployment.

Typically the dependency subcharts would be integrated under the top level `mariadb:` or `postgresql:` keys, where the config can be inherited by the subcharts, and the main app (i.e. Authelia) would also draw its config from those keys. However the database config in the chart is under `storage.mysql` and `storage.postgres` and changing this would be a breaking change.

So I have added booleans `storage.redis.deploy`, `storage.mysql.deploy` and `storage.postgres.deploy` which enable the user to deploy the Bitnami subcharts. This does not affect any existing Authelia deployments. At the moment the user has to copy a few settings (e.g. credentials) from the `mariadb` section to the `storage.mysql` section.

In future we could consider a tighter integration, but it would be a more major refactoring, so let's go with this for now.

I'll keep the [WIP] tag on until I've fully tested this on my own cluster Happy to discuss or tweak this :slightly_smiling_face: 

* Fixes #172 
* Fixes #89 
* Supersedes #223
* Supersedes #225 
* Supersedes #232