### PR TITLE
Bundle Helm charts for Redis, MariaDB and PostgreSQL

### DIFF
--- a/charts/authelia/.helmignore
+++ b/charts/authelia/.helmignore
@@ -6,7 +6,6 @@
 .idea
 *.tmproj
 *.png
-*.tgz
 docs/
 screenshots/
 scripts/

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.0-beta5
+version: 0.9.0-beta6
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -22,15 +22,15 @@ sources:
   - https://www.github.com/authelia/authelia
 dependencies:
   - name: postgresql
-    version: ~15.1.4
+    version: ~15.5.11
     repository: https://charts.bitnami.com/bitnami
     condition: configMap.storage.postgres.deploy
   - name: mariadb
-    version: ~17.0.1
+    version: ~18.2.4
     repository: https://charts.bitnami.com/bitnami
     condition: configMap.storage.mysql.deploy
   - name: redis
-    version: ~19.0.2
+    version: ~19.6.0
     repository: https://charts.bitnami.com/bitnami
     condition: configMap.session.redis.deploy
 maintainers:

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -20,7 +20,19 @@ home: https://www.authelia.com
 sources:
   - https://github.com/authelia/chartrepo/tree/master/charts/authelia
   - https://www.github.com/authelia/authelia
-dependencies: []
+dependencies:
+  - name: postgresql
+    version: ~15.1.4
+    repository: https://charts.bitnami.com/bitnami
+    condition: configMap.storage.postgres.deploy
+  - name: mariadb
+    version: ~17.0.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: configMap.storage.mysql.deploy
+  - name: redis
+    version: ~19.0.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: configMap.session.redis.deploy
 maintainers:
   - name: james-d-elliott
     email: james-d-elliott@users.noreply.github.com

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -4,8 +4,7 @@
 not recommended at this stage for production environments without manual intervention to check the templated manifests
 match your desired state.
 
-This chart uses api version 2 which is only supported by helm v3+. This chart includes Bitnami subcharts to optionally
-deploy `redis`, `postgresql` and/or `mariadb`.
+This chart uses api version 2 which is only supported by helm v3+. This chart includes optional Bitnami subcharts to deploy `redis`, `postgresql`, and/or `mariadb`.
 
 # Breaking Changes
 

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -4,9 +4,8 @@
 not recommended at this stage for production environments without manual intervention to check the templated manifests
 match your desired state.
 
-This chart uses api version 2 which is only supported by helm v3+. This is a ***standalone*** chart intended just to
-deploy *Authelia* on its own. Eventually we may publish an `authelia-bundle` chart which includes `redis` and
-`postgresql`.
+This chart uses api version 2 which is only supported by helm v3+. This chart includes Bitnami subcharts to optionally
+deploy `redis`, `postgresql` and/or `mariadb`.
 
 # Breaking Changes
 
@@ -155,16 +154,23 @@ values.yaml is based on the *Authelia* configuration. See the
 |      configMap.authentication_backend.ldap.enabled      |       Enables LDAP auth when generating the config       |        true        |
 |      configMap.authentication_backend.file.enabled      |       Enables file auth when generating the config       |       false        |
 |             configMap.session.redis.enabled             | Enables redis session storage when generating the config |        true        |
+|             configMap.session.redis.deploy              |                 Deploy a redis instance                  |       false        |
 |          configMap.session.redis.enabledSecret          |    Forces redis password auth using a secret if true     |       false        |
 |    configMap.session.redis.high_availability.enabled    |    Enables redis sentinel when generating the config     |       false        |
 | configMap.session.redis.high_availability.enabledSecret |   Forces sentinel password auth using a secret if true   |       false        |
 |             configMap.storage.local.enabled             |           Enables the SQLite3 storage provider           |       false        |
 |             configMap.storage.mysql.enabled             |            Enables the MySQL storage provider            |       false        |
+|             configMap.storage.mysql.deploy              |                Deploy a MariaDB instance                 |       false        |
 |           configMap.storage.postgres.enabled            |         Enables the PostgreSQL storage provider          |        true        |
+|           configMap.storage.postgres.deploy             |               Deploy a PostgreSQL instance               |       false        |
 |          configMap.notifier.filesystem.enabled          |       Enables the filesystem notification provider       |       false        |
 |             configMap.notifier.smtp.enabled             |          Enables the SMTP notification provider          |        true        |
 |          configMap.notifier.smtp.enabledSecret          |     Forces smtp password auth using a secret if true     |       false        |
 |        configMap.identity_providers.oidc.enabled        |              Enables the OpenID Connect Idp              |       false        |
+
+
+If any of `configMap.session.redis.deploy`, `configMap.storage.mysql.deploy` or `configMap.storage.postgres.deploy` are
+enabled, the corresponding top-level `redis`, `mariadb` or `postgresql` sections must be configured.
 
 ## Secret
 

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -168,9 +168,8 @@ values.yaml is based on the *Authelia* configuration. See the
 |          configMap.notifier.smtp.enabledSecret          |     Forces smtp password auth using a secret if true     |       false        |
 |        configMap.identity_providers.oidc.enabled        |              Enables the OpenID Connect Idp              |       false        |
 
-If any of `configMap.session.redis.deploy`, `configMap.storage.mysql.deploy` or `configMap.storage.postgres.deploy` are
-enabled, the corresponding top-level `redis`, `mariadb` or `postgresql` sections must be configured.
-
+If any of `configMap.session.redis.deploy`, `configMap.storage.mysql.deploy` or `configMap.storage.postgres.deploy` are enabled, the corresponding top-level `redis`, `mariadb` or `postgresql` sections must be configured.
+For more information, refer to the [Bitnami Redis Chart](https://github.com/bitnami/charts/tree/master/bitnami/redis), [Bitnami MariaDB Chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb), and [Bitnami PostgreSQL Chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) documentation.
 ## Secret
 
 The secret section defines how the secret values are added to Authelia. All values that can be a secret are forced as

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -168,7 +168,6 @@ values.yaml is based on the *Authelia* configuration. See the
 |          configMap.notifier.smtp.enabledSecret          |     Forces smtp password auth using a secret if true     |       false        |
 |        configMap.identity_providers.oidc.enabled        |              Enables the OpenID Connect Idp              |       false        |
 
-
 If any of `configMap.session.redis.deploy`, `configMap.storage.mysql.deploy` or `configMap.storage.postgres.deploy` are
 enabled, the corresponding top-level `redis`, `mariadb` or `postgresql` sections must be configured.
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1154,6 +1154,7 @@ configMap:
     ## The redis connection details
     redis:
       enabled: false
+      deploy: false
       enabledSecret: false
       host: 'redis.databases.svc.cluster.local'
       port: 6379
@@ -1313,6 +1314,7 @@ configMap:
     ##
     mysql:
       enabled: false
+      deploy: false
       address: 'tcp://mysql.databases.svc.cluster.local:3306'
       timeout: '5 seconds'
       database: 'authelia'
@@ -1358,6 +1360,7 @@ configMap:
     ##
     postgres:
       enabled: false
+      deploy: false
       address: 'tcp://postgres.databases.svc.cluster.local:5432'
       timeout: '5 seconds'
       database: 'authelia'
@@ -1853,4 +1856,71 @@ persistence:
   size: '100Mi'
 
   selector: {}
-...
+
+# -- Configure mariadb database subchart under this key.
+#    This will be deployed when storage.mysql.deploy is set to true
+#    Currently settings need to be manually copied from here to the storage.mysql section
+#    For more options see [mariadb chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/mariadb)
+mariadb:
+  architecture: standalone
+  auth:
+    database: authelia
+    username: authelia
+    password: authelia
+    rootPassword: authelia
+  primary:
+    resources: {}
+    persistence:
+      enabled: false
+      size: 1Gi
+      # storageClass: ""
+
+# -- Configure postgresql database subchart under this key.
+#    This will be deployed when storage.postgres.deploy is set to true
+#    Currently settings need to be manually copied from here to the storage.postgres section
+#    For more options see [postgresql chart documentation](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+postgresql:
+  auth:
+    postgresPassword: authelia
+    username: authelia
+    password: authelia
+    database: authelia
+  primary:
+    persistence:
+      enabled: false
+      # storageClass: ""
+      size: 1Gi
+    resources: {}
+
+# -- Configure redis database subchart under this key.
+#    This will be deployed when session.redis.deploy is set to true
+#    Currently settings need to be manually copied from here to the session.redis section
+#    For more options see [redis chart documentation](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+redis:
+  architecture: standalone
+  auth:
+    enabled: false
+    sentinel: true
+    password: "redis"
+    existingSecret: ""
+    existingSecretPasswordKey: ""
+    usePasswordFiles: false
+  master:
+    resources: {}
+    priorityClassName: ""
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi
+  replica:
+    replicaCount: 3
+    resources: {}
+    priorityClassName: ""
+    persistence:
+      enabled: false
+      # storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 1Gi


### PR DESCRIPTION
This PR adds basic support for deploying Redis, MariaDB or PostgreSQL as part of an Authelia deployment.

Typically the dependency subcharts would be integrated under the top level `mariadb:` or `postgresql:` keys, where the config can be inherited by the subcharts, and the main app (i.e. Authelia) would also draw its config from those keys. However the database config in the chart is under `storage.mysql` and `storage.postgres` and changing this would be a breaking change.

So I have added booleans `storage.redis.deploy`, `storage.mysql.deploy` and `storage.postgres.deploy` which enable the user to deploy the Bitnami subcharts. This does not affect any existing Authelia deployments. At the moment the user has to copy a few settings (e.g. credentials) from the `mariadb` section to the `storage.mysql` section.

In future we could consider a tighter integration, but it would be a more major refactoring, so let's go with this for now.

I have tested this chart on my own deployment with MariaDB and PostgreSQL databases, plus Redis.

* Fixes #172 
* Fixes #89 
* Supersedes #223
* Supersedes #225 
* Supersedes #232
* Supersedes #243 