### PR TITLE
fix: add subpath to server address

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.0-beta6
+version: 0.9.0-beta7
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -18,7 +18,7 @@ data:
     theme: {{ .Values.configMap.theme | default "light" | squote }}
     default_2fa_method: {{ .Values.configMap.default_2fa_method | default "" | squote }}
     server:
-      address: {{ printf "tcp://0.0.0.0:%d" ((.Values.configMap.server.port | default 9091) | int) | squote }}
+      address: {{ printf "tcp://0.0.0.0:%d%s" ((.Values.configMap.server.port | default 9091) | int) (include "authelia.path" .) | squote }}
       asset_path: {{ .Values.configMap.server.asset_path | default "" | squote }}
       headers:
         csp_template: {{ .Values.configMap.server.headers.csp_template | default "" | squote }}


### PR DESCRIPTION
This fixes an issue when setting a custom path in the values. Not adding the path to the address config creates a bunch of static path 404 errors due to them being redirected to the root path and making Authelia unusable.