### PR TITLE
Fix templating error with authorization_policies.

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.2
+version: 0.9.3
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -387,7 +387,7 @@ data:
         require_pushed_authorization_requests: {{ .Values.configMap.identity_providers.oidc.require_pushed_authorization_requests | default false }}
         {{- with .Values.configMap.identity_providers.oidc.authorization_policies }}
         authorization_policies:
-        {{- range $name, $policy := .Values.configMap.identity_providers.oidc.authorization_policies }}
+        {{- range $name, $policy := $.Values.configMap.identity_providers.oidc.authorization_policies }}
           {{ $name }}:
             default_policy: {{ $policy.default_policy | default "deny" | squote }}
             {{- with $policy.rules }}


### PR DESCRIPTION
Without this change, templating fails when using authorization policies due to the `with` statement changing the scope of the `.` variable on following line. Fix by accessing from global scope `$.`.