### PR TITLE
fix: validation failure message mentioning wrong helm value

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.4
+version: 0.9.5
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/validations.configMap.check.yaml
+++ b/charts/authelia/templates/validations.configMap.check.yaml
@@ -66,7 +66,7 @@
 {{ else if .Values.configMap.server.endpoints.authz }}
     {{ range $authz := .Values.configMap.server.endpoints.authz }}
         {{ if not (has $authz.implementation $authzimpl) }}
-            {{ fail (printf "The implementation name '%s' specified via 'configMap.server.endpoints.automatic_authz_implementations' is not known. Known values are '%s'." $authz.implementation (join "', '" $authzimpl)) }}
+            {{ fail (printf "The implementation name '%s' specified via 'configMap.server.endpoints.authz' is not known. Known values are '%s'." $authz.implementation (join "', '" $authzimpl)) }}
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
configMap validation mentions a wrong helm value in its error message.