### PR TITLE
fix: only include smtp.username if it's set

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.5
+version: 0.9.6
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -306,7 +306,9 @@ data:
       smtp:
         address: {{ $notifier.smtp.address | squote }}
         timeout: {{ include "authelia.func.dquote" ($notifier.smtp.timeout | default "5 seconds") }}
+      {{- if $notifier.smtp.username }}
         username: {{ $notifier.smtp.username | squote }}
+      {{- end }}
         sender: {{ $notifier.smtp.sender | squote }}
         identifier: {{ $notifier.smtp.identifier | squote }}
         subject: {{ $notifier.smtp.subject | squote }}


### PR DESCRIPTION
Including an empty username causes failures with unauthenticated servers