### PR TITLE
Skip smtp username when is PLAIN authenticate

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.13
+version: 0.9.15
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.13
+version: 0.9.14
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.9.12
+version: 0.9.13
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -282,7 +282,11 @@ Returns the number of replicas
       {{- if (include "authelia.stateful" .) }}
         {{- 1 -}}
       {{- else -}}
-        {{- default 1 .Values.pod.replicas -}}
+        {{- if (eq 0 (int .Values.pod.replicas))}}
+        {{- 0 -}}
+        {{- else }}
+        {{- .Values.pod.replicas | default 1 -}}
+        {{- end }}
       {{- end -}}
 {{- end -}}
 

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -394,7 +394,14 @@ data:
             rules:
             {{- range $policy.rules }}
             - policy: {{ .policy | default "deny" | squote }}
-              subject: {{ .subject | squote }}
+              subject:
+              {{- if kindIs "string" .subject }}
+                - [{{ .subject | squote }}]
+              {{- else }}
+              {{- range .subject }}
+                - [{{ include "authelia.squote.join" . }}]
+              {{- end }}
+              {{- end }}
             {{- end }}
             {{- end }}
         {{- end }}

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -306,7 +306,9 @@ data:
       smtp:
         address: {{ $notifier.smtp.address | squote }}
         timeout: {{ include "authelia.func.dquote" ($notifier.smtp.timeout | default "5 seconds") }}
-        username: {{ $notifier.smtp.username | squote }}
+        {{- if $notifier.smtp.username -}}
+          username: {{ $notifier.smtp.username | squote }}
+        {{- end }}
         sender: {{ $notifier.smtp.sender | squote }}
         identifier: {{ $notifier.smtp.identifier | squote }}
         subject: {{ $notifier.smtp.subject | squote }}

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1475,6 +1475,7 @@ configMap:
       ## more information.
       disable_starttls: false
 
+      # Leave empty to authenticate PLAIN: username: ''
       username: 'test'
       password:
         ## Disables this secret and leaves configuring it entirely up to you.


### PR DESCRIPTION
Hello,
if I want to skip smtp authentication I don't need to specify any username. To fix that, an option to leave the username field empty. 