### PR TITLE
fix(authelia): config dir missing on minimal setup

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.3
+version: 0.10.4
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -238,6 +238,10 @@ spec:
           {{- with $mountPropagation := .Values.persistence.mountPropagation }}
           mountPropagation: {{ $mountPropagation }}
           {{- end }}
+        {{- else if and (eq (len .Values.pod.extraVolumes) 0) (eq (len .Values.pod.extraVolumeMounts) 0) }}
+        - mountPath: /config
+          name: authelia
+          readOnly: false
         {{- end }}
         {{- if (include "authelia.enabled.configMap" .) }}
         - mountPath: /configuration.yaml
@@ -282,6 +286,10 @@ spec:
       - name: authelia
         persistentVolumeClaim:
           claimName: {{ default (include "authelia.name" .) .Values.persistence.existingClaim }}
+      {{- else if and (eq (len .Values.pod.extraVolumes) 0) (eq (len .Values.pod.extraVolumeMounts) 0) }}
+      - name: authelia
+        emptyDir:
+          sizeLimit: 100Mi
       {{- end }}
       {{- if (include "authelia.enabled.configMap" .) }}
       - name: config


### PR DESCRIPTION
Fix an issue where the config dir is missing on minimal setups with 4.39.0.