### PR TITLE
Fix typo referencing .Values.configMap.definitions.user_attribute

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.5
+version: 0.10.6
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -67,7 +67,7 @@ data:
       {{- end }}
       {{- if and .Values.configMap.definitions.user_attributes (gt (len .Values.configMap.definitions.user_attributes) 0) }}
       user_attributes:
-        {{- range $attribute, $definition := .Values.configMap.definitions.user_attribute }}
+        {{- range $attribute, $definition := .Values.configMap.definitions.user_attributes }}
         {{ $attribute }}:
           expression: {{ $definition.expression | default "" | squote }}
         {{- end }}


### PR DESCRIPTION
It seems there is a typo when generating user_attributes, where the ranged over value is not pluralised