### PR TITLE
chore: remove default daemonset values

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.10
+version: 0.10.11
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "capabilities.apiVersion.kind" (merge (dict "Kind" $kind)
 kind: {{ $kind }}
 metadata:
   name: {{ include "authelia.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{ include "authelia.labels" (merge (dict "Labels" .Values.pod.labels) .) | nindent 4 }}
   {{- with $annotations := include "authelia.annotations" (merge (dict "Annotations" .Values.pod.annotations) .) }}
   annotations: {{ $annotations | nindent 4 }}
@@ -11,12 +12,16 @@ metadata:
 spec:
   selector:
     matchLabels: {{ include "authelia.matchLabels" . | nindent 6 }}
-  revisionHistoryLimit: {{ default 5 .Values.pod.revisionHistoryLimit }}
+  {{- with .Values.pod.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   {{- if or (eq "StatefulSet" $kind) (eq "Deployment" $kind) }}
   replicas: {{ include "authelia.replicas" . }}
   {{- end }}
   {{- if or (eq "Deployment" $kind) (eq "DaemonSet" $kind) }}
-  minReadySeconds: {{ default 0 .Values.pod.minReadySeconds }}
+  {{- with .Values.pod.minReadySeconds }}
+  minReadySeconds: {{ . }}
+  {{- end }}
   {{- end }}
   {{- if (eq "Deployment" $kind)}}
   {{- $type := include "authelia.deploymentStrategy" . }}
@@ -60,9 +65,15 @@ spec:
       {{- with $tolerations := .Values.pod.tolerations }}
       tolerations: {{ toYaml $tolerations | nindent 8 }}
       {{- end }}
-      hostNetwork: false
-      hostPID: false
-      hostIPC: false
+      {{- with .Values.pod.hostNetwork }}
+      hostNetwork: {{ . }}
+      {{- end }}
+      {{- with .Values.pod.hostPID }}
+      hostPID: {{ . }}
+      {{- end }}
+      {{- with .Values.pod.hostIPC }}
+      hostIPC: {{ . }}
+      {{- end }}
       {{- if (include "authelia.pod.priorityClassName.enabled" .) }}
       priorityClassName: {{ .Values.pod.priorityClassName }}
       {{- end }}
@@ -88,7 +99,9 @@ spec:
       containers:
       - name: authelia
         image: {{ include "authelia.image" . }}
-        imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+        {{- with .Values.image.pullPolicy }}
+        imagePullPolicy: {{ . }}
+        {{- end }}
         {{- $command := list "authelia" }}
         {{- if .Values.pod.command }}
           {{- if kindIs "slice" .Values.pod.command }}{{ $command = .Values.pod.command }}
@@ -111,8 +124,8 @@ spec:
         - {{ . | squote }}
         {{- end }}
         {{- end }}
-        {{- with $resources :=.Values.pod.resources }}
-        resources: {{ toYaml $resources | nindent 10 }}
+        {{- with .Values.pod.resources }}
+        resources: {{ toYaml . | nindent 10 }}
         {{- end }}
         env:
         - name: AUTHELIA_SERVER_DISABLE_HEALTHCHECK
@@ -228,7 +241,9 @@ spec:
         {{- if (include "authelia.enabled.persistentVolumeClaim" .) }}
         - mountPath: /config
           name: authelia
-          readOnly: {{ .Values.persistence.readOnly }}
+          {{- with .Values.persistence.readOnly }}
+          readOnly: {{ . }}
+          {{- end }}
           {{- with $subPath := .Values.persistence.subPath }}
           subPath: {{ $subPath }}
           {{- end }}
@@ -241,7 +256,6 @@ spec:
         {{- else if and (eq (len .Values.pod.extraVolumes) 0) (eq (len .Values.pod.extraVolumeMounts) 0) }}
         - mountPath: /config
           name: authelia
-          readOnly: false
         {{- end }}
         {{- if (include "authelia.enabled.configMap" .) }}
         - mountPath: /configuration.yaml

--- a/charts/authelia/templates/rbac/serviceAccount.yaml
+++ b/charts/authelia/templates/rbac/serviceAccount.yaml
@@ -9,4 +9,4 @@ metadata:
   annotations: {{ $annotations | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
+{{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -246,7 +246,11 @@ pod:
 
   replicas: 1
   revisionHistoryLimit: 5
+  minReadySeconds: 0
   priorityClassName: ''
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
 
   strategy:
     type: 'RollingUpdate'

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -330,12 +330,10 @@ pod:
   # - name: 'TZ'
   #   value: 'Australia/Melbourne'
 
-  resources:
-    limits: {}
+  resources: {}
     # limits:
     #   cpu: '4.00'
     #   memory: '125Mi'
-    requests: {}
     # requests:
     #   cpu: '0.25'
     #   memory: '50Mi'
@@ -348,14 +346,12 @@ pod:
         scheme: 'HTTP'
 
     liveness:
-      initialDelaySeconds: 0
       periodSeconds: 30
       timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 5
 
     readiness:
-      initialDelaySeconds: 0
       periodSeconds: 5
       timeoutSeconds: 5
       successThreshold: 1

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -241,7 +241,11 @@ pod:
 
   replicas: 1
   revisionHistoryLimit: 5
+  minReadySeconds: 0
   priorityClassName: ''
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
 
   strategy:
     type: 'RollingUpdate'
@@ -325,12 +329,10 @@ pod:
   # - name: 'TZ'
   #   value: 'Australia/Melbourne'
 
-  resources:
-    limits: {}
+  resources: {}
     # limits:
     #   cpu: '4.00'
     #   memory: '125Mi'
-    requests: {}
     # requests:
     #   cpu: '0.25'
     #   memory: '50Mi'
@@ -343,14 +345,12 @@ pod:
         scheme: 'HTTP'
 
     liveness:
-      initialDelaySeconds: 0
       periodSeconds: 30
       timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 5
 
     readiness:
-      initialDelaySeconds: 0
       periodSeconds: 5
       timeoutSeconds: 5
       successThreshold: 1


### PR DESCRIPTION
Hi, this small PR aims to avoid templating default Kubernetes values. This should not have any incidence but fixes diff issues with ArgoCD for example:

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/fccacd28-0337-4f58-93f1-2dd444d522f9" />
