### PR TITLE
fix(validations.general.check): override.path inversed condition

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.46
+version: 0.10.47
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/templates/validations.general.check.yaml
+++ b/charts/authelia/templates/validations.general.check.yaml
@@ -1,7 +1,7 @@
 {{ if not .Values.configMap.disabled }}
 
 {{ range $override := .Values.ingress.rulesOverride }}
-{{ if and (not $override.path) (not (eq $override.path "/")) (not (eq $override.path (printf "/%s" $.Values.configMap.server.path))) }}
+{{ if and $override.path (not (eq $override.path "/")) (not (eq $override.path (printf "/%s" $.Values.configMap.server.path))) }}
 {{ fail "The value 'path' for the 'configMap.ingress.rulesOverride' must either not be configured, be configured as '/', or be the same value as the 'configMap.server.path' with the '/' prefix." }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Currently, the rule is triggered when $override.path is not defined.