### PR TITLE
fix(authelia): cache lifespan included incorrectly

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.19
+version: 0.10.20
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -1,6 +1,6 @@
 # authelia
 
-![Version: 0.10.19](https://img.shields.io/badge/Version-0.10.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.4](https://img.shields.io/badge/AppVersion-4.39.4-informational?style=flat-square)
+![Version: 0.10.20](https://img.shields.io/badge/Version-0.10.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.4](https://img.shields.io/badge/AppVersion-4.39.4-informational?style=flat-square)
 
 Authelia is a Single Sign-On Multi-Factor portal for web apps
 

--- a/charts/authelia/files/configuration.server.endpoints.authz.yaml
+++ b/charts/authelia/files/configuration.server.endpoints.authz.yaml
@@ -10,7 +10,7 @@
       - {{ . | squote }}
       {{- end }}
       {{- end }}
-      {{- if semverCompare ">=4.39.0" (include "authelia.version" $) }}
+      {{- if and (semverCompare ">=4.39.0" (include "authelia.version" $)) (not (eq "CookieSession" $strategy.name)) (or (eq (len $strategy.schemes) 0) (has "Basic" $strategy.schemes) (has "basic" $strategy.schemes) (has "BASIC" $strategy.schemes)) }}
       scheme_basic_cache_lifespan: {{ $strategy.scheme_basic_cache_lifespan | default 0 }}
       {{- end }}
   {{- end }}


### PR DESCRIPTION
This fixes an issue where the basic cache lifespan was included when using a strategy that doesn't support it, or when the basic scheme was not included.