### PR TITLE
fix(authelia): ldap defaults

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.21
+version: 0.10.22
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -1,6 +1,6 @@
 # authelia
 
-![Version: 0.10.21](https://img.shields.io/badge/Version-0.10.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.4](https://img.shields.io/badge/AppVersion-4.39.4-informational?style=flat-square)
+![Version: 0.10.22](https://img.shields.io/badge/Version-0.10.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.4](https://img.shields.io/badge/AppVersion-4.39.4-informational?style=flat-square)
 
 Authelia is a Single Sign-On Multi-Factor portal for web apps
 
@@ -445,7 +445,7 @@ false
 			<td>configMap.authentication_backend.ldap.additional_groups_dn</td>
 			<td>string</td>
 			<td><pre lang="json">
-"OU=Groups"
+""
 </pre>
 </td>
 			<td>An additional dn to define the scope of groups.</td>
@@ -454,7 +454,7 @@ false
 			<td>configMap.authentication_backend.ldap.additional_users_dn</td>
 			<td>string</td>
 			<td><pre lang="json">
-"OU=Users"
+""
 </pre>
 </td>
 			<td>An additional dn to define the scope to all users.</td>
@@ -463,7 +463,7 @@ false
 			<td>configMap.authentication_backend.ldap.address</td>
 			<td>string</td>
 			<td><pre lang="json">
-"ldap://openldap.default.svc.cluster.local"
+""
 </pre>
 </td>
 			<td>The address for the ldap server. Format: <scheme>://<address>[:<port>]. Scheme can be ldap or ldaps in the format (port optional).</td>
@@ -697,7 +697,7 @@ false
 			<td>configMap.authentication_backend.ldap.base_dn</td>
 			<td>string</td>
 			<td><pre lang="json">
-"DC=example,DC=com"
+""
 </pre>
 </td>
 			<td>The base dn for every LDAP query.</td>
@@ -886,7 +886,7 @@ false
 			<td>configMap.authentication_backend.ldap.user</td>
 			<td>string</td>
 			<td><pre lang="json">
-"CN=Authelia,DC=example,DC=com"
+""
 </pre>
 </td>
 			<td>The username of the admin user.</td>

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -1266,7 +1266,7 @@ configMap:
 
       # -- The address for the ldap server. Format: <scheme>://<address>[:<port>].
       # Scheme can be ldap or ldaps in the format (port optional).
-      address: 'ldap://openldap.default.svc.cluster.local'
+      address: ''
 
       # -- Connection Timeout.
       timeout: '5 seconds'
@@ -1306,16 +1306,16 @@ configMap:
         timeout: '10 seconds'
 
       # -- The base dn for every LDAP query.
-      base_dn: 'DC=example,DC=com'
+      base_dn: ''
 
       # -- An additional dn to define the scope to all users.
-      additional_users_dn: 'OU=Users'
+      additional_users_dn: ''
 
       # -- The users filter used in search queries to find the user profile based on input filled in login form.
       users_filter: ''
 
       # -- An additional dn to define the scope of groups.
-      additional_groups_dn: 'OU=Groups'
+      additional_groups_dn: ''
 
       # -- The groups filter used in search queries to find the groups of the user.
       groups_filter: ''
@@ -1333,7 +1333,7 @@ configMap:
       permit_feature_detection_failure: false
 
       # -- The username of the admin user.
-      user: 'CN=Authelia,DC=example,DC=com'
+      user: ''
 
       password:
 

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1261,7 +1261,7 @@ configMap:
 
       # -- The address for the ldap server. Format: <scheme>://<address>[:<port>].
       # Scheme can be ldap or ldaps in the format (port optional).
-      address: 'ldap://openldap.default.svc.cluster.local'
+      address: ''
 
       # -- Connection Timeout.
       timeout: '5 seconds'
@@ -1301,16 +1301,16 @@ configMap:
         timeout: '10 seconds'
 
       # -- The base dn for every LDAP query.
-      base_dn: 'DC=example,DC=com'
+      base_dn: ''
 
       # -- An additional dn to define the scope to all users.
-      additional_users_dn: 'OU=Users'
+      additional_users_dn: ''
 
       # -- The users filter used in search queries to find the user profile based on input filled in login form.
       users_filter: ''
 
       # -- An additional dn to define the scope of groups.
-      additional_groups_dn: 'OU=Groups'
+      additional_groups_dn: ''
 
       # -- The groups filter used in search queries to find the groups of the user.
       groups_filter: ''
@@ -1328,7 +1328,7 @@ configMap:
       permit_feature_detection_failure: false
 
       # -- The username of the admin user.
-      user: 'CN=Authelia,DC=example,DC=com'
+      user: ''
 
       password:
 
@@ -1425,11 +1425,11 @@ configMap:
 
         # -- The extra attributes for users.
         extra: {}
-        # extra:
+          # extra:
           # extra_example:
-            # name: ''
-            # multi_valued: false
-            # value_type: 'string'
+          # name: ''
+          # multi_valued: false
+        # value_type: 'string'
 
     ##
     ## File (Authentication Provider)


### PR DESCRIPTION
The LDAP default values are unhelpful and should easily permit users to either not set them or override them which is not actually the case. This fixes that issue.