### PR TITLE
add enabled value to schema

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.38
+version: 0.10.39
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -44,7 +44,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
     - kind: added
-      description: Authelia 4.39.5 support
+      description: Added `enabled` field for charts using this as a dependency
       links: []
   artifacthub.io/images: |
     - name: authelia/authelia

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -42,6 +42,12 @@ kubeDNSDomainOverride: ''
 # @schema
 # required: false
 # @schema
+# -- This field can be used as a condition when authelia is a dependency. This definition is only a placeholder and not used directly by this chart. See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for more info
+enabled: false
+
+# @schema
+# required: false
+# @schema
 image:
 
   # @schema

--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -3235,9 +3235,10 @@
       "title": "configMap"
     },
     "enabled": {
+      "default": "false",
       "description": "This field can be used as a condition when authelia is a dependency. This definition is only a placeholder and not used directly by this chart. See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for more info",
-      "default": false,
-      "type": "boolean"
+      "required": [],
+      "title": "enabled"
     },
     "global": {
       "description": "Global values are values that can be accessed from any chart or subchart by exactly the same name.",

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -37,6 +37,12 @@ kubeDNSDomainOverride: ''
 # @schema
 # required: false
 # @schema
+# -- This field can be used as a condition when authelia is a dependency. This definition is only a placeholder and not used directly by this chart. See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for more info
+enabled: false
+
+# @schema
+# required: false
+# @schema
 image:
 
   # @schema


### PR DESCRIPTION
This adds a boolean value `enabled` to the chart schema which can be used when this chart is pulled in as a dependency.

See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for details.

This is required since additionalProperties is false, so downstream charts cannot define `authelia.enabled` without this.