### PR TITLE
feat(authelia): cross-namespace routing with Gateway API

### DIFF
--- a/charts/authelia/templates/httproute.yaml
+++ b/charts/authelia/templates/httproute.yaml
@@ -29,6 +29,9 @@ spec:
       {{- if $ref.port }}
       port: {{ $ref.port }}
       {{- end }}
+      {{- if $ref.namespace }}
+      namespace: {{ $ref.namespace }}
+      {{- end }}
     {{- end }}
   {{- end }}
   hostnames:

--- a/charts/authelia/templates/httproute.yaml
+++ b/charts/authelia/templates/httproute.yaml
@@ -20,6 +20,9 @@ spec:
       {{- if $ref.port }}
       port: {{ $ref.port }}
       {{- end }}
+      {{- if $ref.namespace }}
+      namespace: {{ $ref.namespace }}
+      {{- end }}
     {{- end }}
   {{- end }}
   hostnames:


### PR DESCRIPTION
Adds support for referencing Gateways from other namespaces in `ingress.gatewayAPI.parentRefs`.

https://gateway-api.sigs.k8s.io/guides/multiple-ns/#route-attachment