### PR TITLE
feat(authelia): externalTrafficPolicy

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.43
+version: 0.10.44
 kubeVersion: ">= 1.13.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -57,7 +57,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
     - kind: added
-      description: Added support for additional configuration options.
+      description: Added support for externalTrafficPolicy setting.
       links: []
   artifacthub.io/images: |
     - name: authelia/authelia

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -1,6 +1,6 @@
 # authelia
 
-![Version: 0.10.43](https://img.shields.io/badge/Version-0.10.43-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.6](https://img.shields.io/badge/AppVersion-4.39.6-informational?style=flat-square)
+![Version: 0.10.44](https://img.shields.io/badge/Version-0.10.44-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.6](https://img.shields.io/badge/AppVersion-4.39.6-informational?style=flat-square)
 
 Authelia is a Single Sign-On Multi-Factor portal for web apps
 
@@ -4394,6 +4394,15 @@ null
 </pre>
 </td>
 			<td>Cluster IP for the Authelia service manifest.</td>
+		</tr>
+		<tr>
+			<td>service.externalTrafficPolicy</td>
+			<td>string</td>
+			<td><pre lang="json">
+"Cluster"
+</pre>
+</td>
+			<td>Use value Local to get external IP addresses.</td>
 		</tr>
 		<tr>
 			<td>service.labels</td>

--- a/charts/authelia/templates/service.yaml
+++ b/charts/authelia/templates/service.yaml
@@ -35,3 +35,4 @@ spec:
       port: {{ .Values.configMap.telemetry.metrics.port | default 9959 }}
       targetPort: metrics
     {{- end }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | default "Cluster" }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -187,6 +187,13 @@ service:
   # -- (string) Cluster IP for the Authelia service manifest.
   clusterIP: ~
 
+  # @schema
+  # type: [string, null]
+  # required: false
+  # @schema
+  # -- (string) Use value Local to get external IP addresses.
+  externalTrafficPolicy: Cluster
+
 # @schema
 # required: false
 # @schema

--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -5156,6 +5156,16 @@
             "null"
           ]
         },
+        "externalTrafficPolicy": {
+          "default": "Cluster",
+          "description": "(string) Use value Local to get external IP addresses.",
+          "required": [],
+          "title": "externalTrafficPolicy",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "labels": {
           "additionalProperties": true,
           "description": "Extra labels for service manifest.",

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -182,6 +182,13 @@ service:
   # -- (string) Cluster IP for the Authelia service manifest.
   clusterIP: ~
 
+  # @schema
+  # type: [string, null]
+  # required: false
+  # @schema
+  # -- (string) Use value Local to get external IP addresses.
+  externalTrafficPolicy: Cluster
+
 # @schema
 # required: false
 # @schema


### PR DESCRIPTION
add externalTrafficPolicy option. this needed for correct IP rules. from official doc
<https://www.authelia.com/integration/kubernetes/introduction/#external-traffic-policy>

default Cluster, matching kube default
make docs && make schema