### PR TITLE
fix: render externalTrafficPolicy only conditionally

### DIFF
--- a/charts/authelia/templates/service.yaml
+++ b/charts/authelia/templates/service.yaml
@@ -35,4 +35,7 @@ spec:
       port: {{ .Values.configMap.telemetry.metrics.port | default 9959 }}
       targetPort: metrics
     {{- end }}
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | default "Cluster" }}
+  {{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  


### PR DESCRIPTION
This fixes https://github.com/authelia/chartrepo/issues/362 by only rendering the `externalTrafficPolicy` when the user explicitly sets one.