### PR TITLE
feat: add min required version check

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,6 +12,11 @@ steps:
   label: ":helm: Linting (Chart Testing)"
   if: build.branch != "gh-pages" && build.env("CHART_CHANGES") == "true"
 
+- command: "make test-chart"
+  key: "unit-tests"
+  label: ":test_tube: Helm Unit Tests"
+  if: build.branch != "gh-pages" && build.env("CHART_CHANGES") == "true"
+
 - command: "make lint-chart-package"
   key: "lint-package"
   label: ":package: Package Chart (Chart Releaser)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 GO=go
+HELM_UNITTEST_VERSION ?= v1.0.3
+HELM_UNITTEST_REPO ?= https://github.com/helm-unittest/helm-unittest
 
 docs: install-helm-docs
 	helm-docs
@@ -20,6 +22,17 @@ lint-chart-package:
 lint-docs:
 	@(git diff-index --quiet HEAD charts/**/README.md) || (echo "Documentation is outdated, run make docs") && (git diff --color-words charts/**/README.md) && false
 	@echo "Documentation up to date"
+
+helm-unittest-install:
+	@if ! helm plugin list | tail -n +2 | awk '{print $$1}' | grep -q "^unittest$$"; then \
+		echo "Installing helm-unittest plugin $(HELM_UNITTEST_VERSION)"; \
+		helm plugin install $(HELM_UNITTEST_REPO) --version $(HELM_UNITTEST_VERSION) --verify=false; \
+	else \
+		echo "helm-unittest plugin already installed"; \
+	fi
+
+test-chart: helm-unittest-install
+	@helm unittest charts/authelia
 
 install: install-helm-docs install-helm-schema
 

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ development.
 ## Getting Started
 
 Visit the [Helm Repository](https://charts.authelia.com) for instructions.
+
+## Testing
+
+To run the tests locally you can use the following command:
+
+```bash
+make test-chart
+```
+
+This will run the unit tests for the chart.

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -3026,6 +3026,15 @@ false
 			<td>This field can be used as a condition when authelia is a dependency. This definition is only a placeholder and not used directly by this chart. See https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags for more info</td>
 		</tr>
 		<tr>
+			<td>image.minimumVersion</td>
+			<td>string</td>
+			<td><pre lang="json">
+"4.39.5"
+</pre>
+</td>
+			<td>The minimum Authelia version that must be satisfied by the resolved image tag. Set to '' to disable the validation.</td>
+		</tr>
+		<tr>
 			<td>image.pullPolicy</td>
 			<td>string</td>
 			<td><pre lang="json">

--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -1,10 +1,17 @@
 {{/*
+Return the resolved image tag.
+*/}}
+{{- define "authelia.image.tag" -}}
+    {{- default .Chart.AppVersion .Values.image.tag | toString -}}
+{{- end -}}
+
+{{/*
 Return the proper image name
 */}}
 {{- define "authelia.image" -}}
     {{- $registryName := default "docker.io" .Values.image.registry -}}
     {{- $repositoryName := default "authelia/authelia" .Values.image.repository -}}
-    {{- $tag := .Values.image.tag | default .Chart.AppVersion  | toString -}}
+    {{- $tag := include "authelia.image.tag" . -}}
     {{- if hasPrefix "sha256:" $tag }}
     {{- printf "%s/%s@%s" $registryName $repositoryName $tag -}}
     {{- else -}}

--- a/charts/authelia/templates/validations.image.check.yaml
+++ b/charts/authelia/templates/validations.image.check.yaml
@@ -1,0 +1,24 @@
+{{/*
+    Validate minimum Authelia image version requirements.
+*/}}
+{{- $minimumVersion := .Values.image.minimumVersion | default "" -}}
+{{- if $minimumVersion }}
+    {{- $imageTag := include "authelia.image.tag" . -}}
+    {{- $semverPattern := "^[vV]?[0-9]+\\.[0-9]+\\.[0-9]+.*$" -}}
+
+    {{- if hasPrefix "sha256:" $imageTag }}
+        {{- fail "image.minimumVersion can't be used when the image tag is specified as a digest" -}}
+    {{- else if not (regexMatch $semverPattern $minimumVersion) }}
+        {{- fail (printf "The configured image.minimumVersion value '%s' is not a semantic version" $minimumVersion) -}}
+    {{- else if not (regexMatch $semverPattern $imageTag) }}
+        {{- fail (printf "The resolved Authelia image tag '%s' is not a semantic version while image.minimumVersion is configured; please use a semantic version tag or unset image.minimumVersion" $imageTag) -}}
+    {{- else -}}
+        {{- $normalizedMinimum := regexReplaceAll "(?i)^v" $minimumVersion "" -}}
+        {{- $normalizedTag := regexReplaceAll "(?i)^v" $imageTag "" -}}
+        {{- $constraint := printf ">=%s" $normalizedMinimum -}}
+        {{- if not (semverCompare $constraint $normalizedTag) }}
+            {{- fail (printf "The resolved Authelia image tag '%s' is older than the minimum supported version '%s'. Please select a compatible image tag or adjust image.minimumVersion." $imageTag $minimumVersion) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+

--- a/charts/authelia/tests/validations_image_test.yaml
+++ b/charts/authelia/tests/validations_image_test.yaml
@@ -1,0 +1,52 @@
+suite: Image minimum version validation
+templates:
+  - templates/validations.image.check.yaml
+tests:
+  - it: renders successfully when tag meets the minimum version
+    set:
+      image.tag: 4.39.6
+      image.minimumVersion: 4.39.5
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders successfully when using semantic versioning with minimum version
+    set:
+      image.tag: v4.39.6
+      image.minimumVersion: v4.39.5
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders successfully when the minimum version check is disabled
+    set:
+      image.tag: 4.39.3
+      image.minimumVersion: ''
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when the tag is a digest but a minimum version is set
+    set:
+      image.tag: sha256:9c644a7a7b3ddf3bddad78df8fd357e1a527c99ad4a3ec3c7f1e4b2c1bbedbab
+      image.minimumVersion: 4.39.5
+    asserts:
+      - failedTemplate:
+          errorMessage: "image.minimumVersion can't be used when the image tag is specified as a digest"
+
+  - it: fails when the tag is older than the minimum version
+    set:
+      image.tag: 4.39.3
+      image.minimumVersion: 4.39.5
+    asserts:
+      - failedTemplate:
+          errorMessageRegex: "older than the minimum supported version"
+  
+  - it: fails when the semantic version tag is older than the minimum version
+    set:
+      image.tag: v4.39.3
+      image.minimumVersion: v4.39.5
+    asserts:
+      - failedTemplate:
+          errorMessageRegex: "older than the minimum supported version"
+

--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -3305,6 +3305,12 @@
           "description": "The tag to use from the registry.",
           "required": [],
           "title": "tag"
+        },
+        "minimumVersion": {
+          "default": "4.39.5",
+          "description": "The minimum Authelia version that must be satisfied by the resolved image tag. Set to '' to disable the validation.",
+          "required": [],
+          "title": "minimumVersion"
         }
       },
       "required": [],

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -67,6 +67,12 @@ image:
   # @schema
   # required: false
   # @schema
+  # -- The minimum Authelia version that must be satisfied by the resolved image tag. Set to '' to disable the validation.
+  minimumVersion: '4.39.5'
+
+  # @schema
+  # required: false
+  # @schema
   # -- The pull policy for the standard image.
   pullPolicy: 'IfNotPresent'
 


### PR DESCRIPTION
This should be bumped each time there is a breaking change in the chart config wrt what Authelia can successfully be deployed with The 'minimumVersion' can be overwritten be the user to 'by-pass' the fail-safe.

This PR is the result of my silly mistake in #380  

I noticed there are versions checks on a other places in the chart but that is probably a lot more maintenance and cognitive load than just one version check on the whole chart.. Perhaps they can be removed