### PR TITLE
fix(traefikCRD): correct maxResponseBodySize template syntax

### DIFF
--- a/charts/authelia/templates/traefikCRD/middlewares.yaml
+++ b/charts/authelia/templates/traefikCRD/middlewares.yaml
@@ -15,8 +15,8 @@ spec:
   forwardAuth:
     address: {{ (include "authelia.ingress.traefikCRD.middleware.forwardAuth.address" (merge (dict "Name" $name) $)) | squote }}
     trustForwardHeader: true
-    {{- if gt  $.Values.ingress.traefikCRD.middlewares.auth.maxResponseBodySize 0 }}
-    maxResponseBodySize: $.Values.ingress.traefikCRD.middlewares.auth.maxResponseBodySize 0)
+    {{- if gt (int $.Values.ingress.traefikCRD.middlewares.auth.maxResponseBodySize) 0 }}
+    maxResponseBodySize: {{ $.Values.ingress.traefikCRD.middlewares.auth.maxResponseBodySize }}
     {{- end }}
     {{- with $.Values.ingress.traefikCRD.middlewares.auth.authResponseHeaders }}
     authResponseHeaders:


### PR DESCRIPTION
Also cast the value to int to ensure proper comparison with gt.

Fixes #397