### PR TITLE
feat(authelia): max response body size

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.10.54
+version: 0.10.55
 kubeVersion: ">= 1.30.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -57,7 +57,9 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
     - kind: added
-      description: Authelia 4.39.18.
+      description: Option to enable maxResponseBodyBytes
+    - kind: removed
+      description: Option to set maxResponseBodyBytes value
   artifacthub.io/images: |
     - name: authelia/authelia
       image: ghcr.io/authelia/authelia:4.39.18

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -1,6 +1,6 @@
 # authelia
 
-![Version: 0.10.54](https://img.shields.io/badge/Version-0.10.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.18](https://img.shields.io/badge/AppVersion-4.39.18-informational?style=flat-square)
+![Version: 0.10.55](https://img.shields.io/badge/Version-0.10.55-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.18](https://img.shields.io/badge/AppVersion-4.39.18-informational?style=flat-square)
 
 Authelia is a Single Sign-On Multi-Factor portal for web apps
 
@@ -3520,6 +3520,15 @@ false
 			<td>Defines the ForwardAuth Middleware Auth Response Headers.</td>
 		</tr>
 		<tr>
+			<td>ingress.traefikCRD.middlewares.auth.enableMMaxResponseBodySize</td>
+			<td>bool</td>
+			<td><pre lang="json">
+false
+</pre>
+</td>
+			<td>Sets an appropriate value for maxResponseBodySize.</td>
+		</tr>
+		<tr>
 			<td>ingress.traefikCRD.middlewares.auth.endpointOverride</td>
 			<td>string</td>
 			<td><pre lang="json">
@@ -3527,15 +3536,6 @@ false
 </pre>
 </td>
 			<td>Overrides the endpoint used for the middleware. This is the portion of the endpoint after '/api/authz/'.</td>
-		</tr>
-		<tr>
-			<td>ingress.traefikCRD.middlewares.auth.maxResponseBodySize</td>
-			<td>int</td>
-			<td><pre lang="json">
-0
-</pre>
-</td>
-			<td>Sets the value for maxResponseBodySize.</td>
 		</tr>
 		<tr>
 			<td>ingress.traefikCRD.middlewares.auth.nameOverride</td>

--- a/charts/authelia/templates/traefikCRD/middlewares.yaml
+++ b/charts/authelia/templates/traefikCRD/middlewares.yaml
@@ -15,8 +15,8 @@ spec:
   forwardAuth:
     address: {{ (include "authelia.ingress.traefikCRD.middleware.forwardAuth.address" (merge (dict "Name" $name) $)) | squote }}
     trustForwardHeader: true
-    {{- if gt  $.Values.ingress.traefikCRD.middlewares.auth.maxResponseBodySize 0 }}
-    maxResponseBodySize: $.Values.ingress.traefikCRD.middlewares.auth.maxResponseBodySize 0)
+    {{- if gt  $.Values.ingress.traefikCRD.middlewares.auth.enableMMaxResponseBodySize 0 }}
+    maxResponseBodySize: 2097152
     {{- end }}
     {{- with $.Values.ingress.traefikCRD.middlewares.auth.authResponseHeaders }}
     authResponseHeaders:

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -390,8 +390,8 @@ ingress:
         # @schema
         # required: false
         # @schema
-        # -- Sets the value for maxResponseBodySize.
-        maxResponseBodySize: 0
+        # -- Sets an appropriate value for maxResponseBodySize.
+        enableMMaxResponseBodySize: false
 
         # @schema
         # required: false

--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -3745,17 +3745,17 @@
                       "required": [],
                       "title": "authResponseHeaders"
                     },
+                    "enableMMaxResponseBodySize": {
+                      "default": "false",
+                      "description": "Sets an appropriate value for maxResponseBodySize.",
+                      "required": [],
+                      "title": "enableMMaxResponseBodySize"
+                    },
                     "endpointOverride": {
                       "default": "",
                       "description": "Overrides the endpoint used for the middleware. This is the portion of the endpoint after '/api/authz/'.",
                       "required": [],
                       "title": "endpointOverride"
-                    },
-                    "maxResponseBodySize": {
-                      "default": "0",
-                      "description": "Sets the value for maxResponseBodySize.",
-                      "required": [],
-                      "title": "maxResponseBodySize"
                     },
                     "nameOverride": {
                       "default": "",

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -385,8 +385,8 @@ ingress:
         # @schema
         # required: false
         # @schema
-        # -- Sets the value for maxResponseBodySize.
-        maxResponseBodySize: 0
+        # -- Sets an appropriate value for maxResponseBodySize.
+        enableMMaxResponseBodySize: false
 
         # @schema
         # required: false


### PR DESCRIPTION
Removes the maxResponseBodySize for enableMaxResponseBodySize.

Fixes #397, Closes #398, Closes #391