### PR TITLE
fix(authelia): skip SMTP AUTH when username/password not configured

### DIFF
--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -523,7 +523,9 @@ data:
       smtp:
         address: {{ $notifier.smtp.address | squote }}
         timeout: {{ include "authelia.func.dquote" ($notifier.smtp.timeout | default "5 seconds") }}
+        {{- if $notifier.smtp.username }}
         username: {{ $notifier.smtp.username | squote }}
+        {{- end }}
         sender: {{ $notifier.smtp.sender | squote }}
         identifier: {{ $notifier.smtp.identifier | squote }}
         subject: {{ $notifier.smtp.subject | squote }}

--- a/charts/authelia/templates/deployment.yaml
+++ b/charts/authelia/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
         {{- end }}
         {{- if $.Values.configMap.notifier.smtp }}
         {{- with $secret := .Values.configMap.notifier.smtp.password }}
-        {{- if and (not $secret.disabled) $.Values.configMap.notifier.smtp.enabled  }}
+        {{- if and (not $secret.disabled) $.Values.configMap.notifier.smtp.enabled $.Values.configMap.notifier.smtp.username }}
         - name: AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE
           value: {{ include "authelia.secret.env.path" (merge (dict "MountPath" (include "authelia.secret.mountPath" $) "SecretName" $secret.secret_name "SecretPath" (include "authelia.secret.path.smtp.password" $)) $) }}
         {{- end }}
@@ -372,7 +372,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- with $secret := .Values.configMap.notifier.smtp.password }}
-          {{- if and (not $secret.disabled) (not $secret.secret_name) $.Values.configMap.notifier.smtp.enabled }}
+          {{- if and (not $secret.disabled) (not $secret.secret_name) $.Values.configMap.notifier.smtp.enabled $.Values.configMap.notifier.smtp.username }}
           - key: {{ include "authelia.secret.path.smtp.password" $ }}
             path: {{ include "authelia.secret.path.smtp.password" $ }}
           {{- end }}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -28,8 +28,8 @@ data:
     {{- if and (include "authelia.secret.generate" .Values.configMap.authentication_backend.ldap.password) .Values.configMap.authentication_backend.ldap.enabled }}
     {{ include "authelia.secret.path.ldap.password" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.authentication_backend.ldap.password) .) }}
     {{- end }}
-     {{- if and .Values.configMap.notifier.smtp.password.value .Values.configMap.notifier.smtp.enabled }}
-     {{ include "authelia.secret.path.smtp.password" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.notifier.smtp.password) .) }}
+    {{- if and (include "authelia.secret.generate" .Values.configMap.notifier.smtp.password) .Values.configMap.notifier.smtp.enabled .Values.configMap.notifier.smtp.username }}
+    {{ include "authelia.secret.path.smtp.password" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.notifier.smtp.password) .) }}
     {{- end }}
     {{- if include "authelia.secret.generate" .Values.configMap.storage.encryption_key }}
     {{ include "authelia.secret.path.storage.encryption_key" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.storage.encryption_key) .) }}

--- a/charts/authelia/templates/secret.yaml
+++ b/charts/authelia/templates/secret.yaml
@@ -28,8 +28,8 @@ data:
     {{- if and (include "authelia.secret.generate" .Values.configMap.authentication_backend.ldap.password) .Values.configMap.authentication_backend.ldap.enabled }}
     {{ include "authelia.secret.path.ldap.password" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.authentication_backend.ldap.password) .) }}
     {{- end }}
-    {{- if and (include "authelia.secret.generate" .Values.configMap.notifier.smtp.password) .Values.configMap.notifier.smtp.enabled }}
-    {{ include "authelia.secret.path.smtp.password" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.notifier.smtp.password) .) }}
+     {{- if and .Values.configMap.notifier.smtp.password.value .Values.configMap.notifier.smtp.enabled }}
+     {{ include "authelia.secret.path.smtp.password" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.notifier.smtp.password) .) }}
     {{- end }}
     {{- if include "authelia.secret.generate" .Values.configMap.storage.encryption_key }}
     {{ include "authelia.secret.path.storage.encryption_key" . }}: {{ include "authelia.secret.value.standard" (merge (dict "Lookup" $secretData "Secret" .Values.configMap.storage.encryption_key) .) }}


### PR DESCRIPTION
## Problem

When `notifier.smtp.username` and `notifier.smtp.password` are not configured (unauthenticated SMTP relay), the chart has two bugs:

1. **`configMap.yaml`** renders `username: ''` unconditionally. Authelia interprets any `username` key — even empty string — as a signal to attempt SMTP AUTH, which fails on servers that don't advertise AUTH mechanisms (e.g. internal Postfix relay trusted via `mynetworks`):
   ```
   level=error msg="notifier: smtp: failed to dial connection: SMTP AUTH failed: unsupported SMTP AUTH types: "
   ```

2. **`secret.yaml`** uses `authelia.secret.generate` for the SMTP password, which auto-generates a random 128-char password when no value is provided. This random password is then used in the AUTH attempt, causing the same failure.

Both issues prevent Authelia from working with unauthenticated internal SMTP relays.

## Fix

- `configMap.yaml`: wrap `username` in a conditional — only render if non-empty
- `secret.yaml`: only render the SMTP password secret if an explicit `value` is provided by the user — never auto-generate it

## Testing

Deploy Authelia with SMTP notifier configured without credentials:

```yaml
configMap:
  notifier:
    smtp:
      enabled: true
      address: smtp://mail.internal:587
      sender: noreply@example.com
      disable_require_tls: true
      disable_starttls: true
```

Before fix: Authelia fails with `SMTP AUTH failed: unsupported SMTP AUTH types`
After fix: Authelia connects and sends mail without attempting AUTH