### PR TITLE
fix(authelia): allow string secret_name in values.schema.json

### DIFF
--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -687,7 +687,7 @@
                       "default": "~",
                       "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                       "title": "secret_name",
-                      "type": "null"
+                      "type": ["string", "null"]
                     },
                     "value": {
                       "default": "",
@@ -1015,7 +1015,7 @@
                   "default": "~",
                   "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                   "title": "secret_name",
-                  "type": "null"
+                  "type": ["string", "null"]
                 },
                 "value": {
                   "default": "",
@@ -2036,7 +2036,7 @@
                       "default": "~",
                       "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                       "title": "secret_name",
-                      "type": "null"
+                      "type": ["string", "null"]
                     },
                     "value": {
                       "default": "",
@@ -2584,7 +2584,7 @@
                       "default": "~",
                       "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                       "title": "secret_name",
-                      "type": "null"
+                      "type": ["string", "null"]
                     },
                     "value": {
                       "default": "",
@@ -2759,7 +2759,7 @@
                       "default": "~",
                       "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                       "title": "secret_name",
-                      "type": "null"
+                      "type": ["string", "null"]
                     },
                     "value": {
                       "default": "",
@@ -3679,7 +3679,7 @@
                   "default": "~",
                   "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                   "title": "secret_name",
-                  "type": "null"
+                  "type": ["string", "null"]
                 },
                 "value": {
                   "default": "",
@@ -3782,7 +3782,7 @@
                           "default": "~",
                           "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                           "title": "secret_name",
-                          "type": "null"
+                          "type": ["string", "null"]
                         },
                         "value": {
                           "default": "",
@@ -4023,7 +4023,7 @@
                   "default": "~",
                   "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                   "title": "secret_name",
-                  "type": "null"
+                  "type": ["string", "null"]
                 },
                 "value": {
                   "default": "",
@@ -4110,7 +4110,7 @@
                       "default": "~",
                       "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                       "title": "secret_name",
-                      "type": "null"
+                      "type": ["string", "null"]
                     },
                     "value": {
                       "default": "",
@@ -4247,7 +4247,7 @@
                       "default": "~",
                       "description": "The secret name. The ~ name is special as it is the secret we generate either automatically or via the\nsecret_value option below.",
                       "title": "secret_name",
-                      "type": "null"
+                      "type": ["string", "null"]
                     },
                     "value": {
                       "default": "",


### PR DESCRIPTION
## Summary

#407 set `"type": "null"` for `secret_name` in 10 places under `charts/authelia/values.schema.json`. The field's description still reads:

> The secret name. The ~ name is special as it is the secret we generate either automatically or via the `secret_value` option below.

…implying non-`~` string values are valid as references to externally-managed Secrets. Templates back this up — `deployment.yaml` and helpers consume `$secret.secret_name` as a string when forming Secret mount paths.

The default `secret_name: ~` still works, but any value referencing an existing Secret (`secret_name: my-secret`) is rejected by `helm install` / `helm template`:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
authelia:
- at '/configMap/storage/encryption_key/secret_name': got string, want null
- at '/configMap/session/encryption_key/secret_name': got string, want null
- at '/configMap/identity_providers/oidc/hmac_secret/secret_name': got string, want null
- at '/configMap/identity_validation/reset_password/secret/secret_name': got string, want null
```

This blocks the external-Secret pattern (External Secrets Operator, Sealed Secrets, manually-managed Secrets) that the chart's own description encourages.

## Change

Switch `"type": "null"` to `"type": ["string", "null"]` for the 10 affected `secret_name` schema nodes. Templates already accept both forms; only the schema was over-tightened in #407.

## Verification

`helm template` against a values file that sets `secret_name` on `storage`, `session`, `identity_providers.oidc.hmac_secret`, and `identity_validation.reset_password`:
- **before:** 4 schema validation errors (one per `secret_name`)
- **after:** succeeds, renders 608 lines

Default `secret_name: ~` still validates after the change.

Reproduces against current `master` (`683efaf`).
