### PR TITLE
fix(authelia): render maxSurge in DaemonSet rolling update strategy

### DIFF
--- a/charts/authelia/templates/_helpers.tpl
+++ b/charts/authelia/templates/_helpers.tpl
@@ -277,9 +277,10 @@ Returns the rollingUpdate spec
             {{- end -}}
         {{- end -}}
     {{- else if eq "DaemonSet" (include "authelia.pod.kind" .) -}}
-        {{ $result = dict "maxUnavailable" "25%" }}
+        {{ $result = dict "maxSurge" "25%" "maxUnavailable" "25%" }}
         {{- if .Values.pod.strategy -}}
             {{- if .Values.pod.strategy.rollingUpdate -}}
+                {{- $_ := set $result "maxSurge" (.Values.pod.strategy.rollingUpdate.maxSurge | default "25%") -}}
                 {{- $_ := set $result "maxUnavailable" (.Values.pod.strategy.rollingUpdate.maxUnavailable | default "25%") -}}
             {{- end -}}
         {{- end -}}

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -489,7 +489,10 @@ pod:
       # -- RollingUpdate partition value.
       partition: 0
 
-      # -- RollingUpdate max surge value.
+      # -- RollingUpdate max surge value. Any value greater than 0 means the controller will briefly run more pods than
+      # the desired replica count during a rollout. This is unsafe with backends that cannot tolerate two pods running
+      # concurrently (e.g. SQLite local storage, in-memory sessions, or ReadWriteOnce PVCs). For those backends set
+      # this to '0%' and maxUnavailable to '100%'. Not used when pod.kind is StatefulSet.
       maxSurge: '25%'
 
       # -- RollingUpdate max unavailable value.


### PR DESCRIPTION
The DaemonSet branch of the authelia.rollingUpdate helper only rendered maxUnavailable, silently dropping any user-supplied maxSurge value. This made zero-downtime updates impossible when pod.kind is DaemonSet, since maxSurge defaulted to 0 at the API server.

Mirror the Deployment branch so both maxSurge and maxUnavailable are rendered for DaemonSets, with the same '25%' default.

Also clarifies the maxSurge doc comment in values.yaml: any non-zero surge value is unsafe with backends that cannot tolerate two pods running concurrently (SQLite local storage, in-memory sessions, or ReadWriteOnce PVCs); those deployments should set maxSurge to '0%' and maxUnavailable to '100%'.