### PR TITLE
feat(authelia): support custom authelia url ports

### DIFF
--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -53,11 +53,12 @@ It is expected you will configure at least the following sections/values:
   in [the documentation](https://www.authelia.com/configuration))
   - The `configMap.session.cookies` section contains the domain configuration for the Authelia portal and session
     cookies:
-    - The full Authelia URL will be in the format of `https://[<subdomain>.]<domain>[/<subpath>]` (part within the square braces is
+    - The full Authelia URL will be in the format of `https://[<subdomain>.]<domain>[:<port>][/<subpath>]` (part within the square braces is
       omitted if not configured) i.e. `domain` of `example.com` and `subdomain` empty yields `https://example.com` and
-      `subdomain` of `auth` yields `https://auth.example.com`. The `subpath` is also optionally included.
+      `subdomain` of `auth` yields `https://auth.example.com`. The `port` and `subpath` are also optionally included.
     - The `domain` option is required.
     - The `subdomain` option is generally required.
+    - The `port` option is optional and only affects the generated Authelia URL. It does not affect the cookie domain.
     - The `path` option is generally **_NOT_** required or recommended. Every domain that has this option configured
       MUST have the same value i.e. you can have one blank and one configured but all those that are configured must be
       the same, and in addition if configured at all the `configMap.server.path` option must have the same value.
@@ -594,4 +595,3 @@ Kubernetes: `>= 1.30.0-0`
 | service.port | int | `80` | Port for the Authelia service manifest. |
 | service.type | string | `"ClusterIP"` | The service type to generate for the Authelia pods. |
 | versionOverride | string | `""` | Version Override allows changing some chart characteristics that render only on specific versions. This does NOT affect the image used, please see the below image section instead for this. If this value is not specified, it's assumed the appVersion of the chart is the version. The format of this value  is x.x.x, for example 4.100.0. Minimum value is 4.38.0, and support is not guaranteed. |
-

--- a/charts/authelia/ci/authelia-url-port.yaml
+++ b/charts/authelia/ci/authelia-url-port.yaml
@@ -1,0 +1,14 @@
+configMap:
+  session:
+    cookies:
+      - domain: example.com
+        subdomain: auth
+        port: 8443
+ingress:
+  enabled: true
+  tls:
+    enabled: true
+  traefikCRD:
+    enabled: true
+    tls:
+      certResolver: default

--- a/charts/authelia/templates/_ingress.tpl
+++ b/charts/authelia/templates/_ingress.tpl
@@ -1,8 +1,8 @@
 {{- define "authelia.ingress.uri" -}}
     {{- if .Path }}
-    {{- printf "https://%s/%s" (include "authelia.ingress.host" .) .Path }}
+    {{- printf "https://%s/%s" (include "authelia.ingress.authority" .) .Path }}
     {{- else }}
-    {{- printf "https://%s" (include "authelia.ingress.host" .) }}
+    {{- printf "https://%s" (include "authelia.ingress.authority" .) }}
     {{- end }}
 {{- end -}}
 
@@ -14,6 +14,26 @@
     {{- printf "%s.%s" .SubDomain .Domain }}
     {{- else }}
     {{- .Domain }}
+    {{- end }}
+{{- end }}
+
+{{/*
+    Returns the ingress authority value including the optional port.
+*/}}
+{{- define "authelia.ingress.authority" -}}
+    {{- $port := int (default 0 .Port) -}}
+    {{- if .SubDomain }}
+        {{- if gt $port 0 }}
+            {{- printf "%s.%s:%d" .SubDomain .Domain $port }}
+        {{- else }}
+            {{- printf "%s.%s" .SubDomain .Domain }}
+        {{- end }}
+    {{- else }}
+        {{- if gt $port 0 }}
+            {{- printf "%s:%d" .Domain $port }}
+        {{- else }}
+            {{- .Domain }}
+        {{- end }}
     {{- end }}
 {{- end }}
 

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -394,7 +394,7 @@ data:
       cookies:
       {{- range $cookie := (required "The value 'configMap.session.cookies' must have at least one configuration" $session.cookies) }}
         - domain: {{ required "All 'domain' values for the 'configMap.session.cookies' configurations must be configured" .domain | squote }}
-          authelia_url: {{ include "authelia.ingress.uri" (merge (dict "SubDomain" $cookie.subdomain "Domain" $cookie.domain "Path" $cookie.path) $) | squote }}
+          authelia_url: {{ include "authelia.ingress.uri" (merge (dict "SubDomain" $cookie.subdomain "Domain" $cookie.domain "Port" $cookie.port "Path" $cookie.path) $) | squote }}
           {{- if $cookie.default_redirection_url }}
           default_redirection_url: {{ $cookie.default_redirection_url | squote }}
           {{- end }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -3163,6 +3163,10 @@ configMap:
     #       required: false
     #     domain:
     #       type: string
+    #     port:
+    #       type: integer
+    #       minimum: 1
+    #       maximum: 65535
     #     path:
     #       type: string
     #       required: false
@@ -3194,6 +3198,9 @@ configMap:
 
         ## The domain for cookie and to build the Authelia URL.
         # domain: ''
+
+        ## The port to suffix the generated Authelia URL with. This option does not affect the cookie domain.
+        # port: 443
 
         ## The path to suffix the domain with. For example using `domain` value `example.com` and `subdomain` value
         ## `auth` and `path` value `auth` should yield the URL `https://auth.example.com/auth`.

--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -3658,6 +3658,11 @@
                   "path": {
                     "type": "string"
                   },
+                  "port": {
+                    "maximum": 65535,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
                   "same_site": {
                     "enum": [
                       "lax",

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -1988,6 +1988,10 @@ configMap:
     #       type: string
     #     domain:
     #       type: string
+    #     port:
+    #       type: integer
+    #       minimum: 1
+    #       maximum: 65535
     #     path:
     #       type: string
     #     default_redirection_url:
@@ -2013,6 +2017,9 @@ configMap:
 
         ## The domain for cookie and to build the Authelia URL.
         # domain: ''
+
+        ## The port to suffix the generated Authelia URL with. This option does not affect the cookie domain.
+        # port: 443
 
         ## The path to suffix the domain with. For example using `domain` value `example.com` and `subdomain` value
         ## `auth` and `path` value `auth` should yield the URL `https://auth.example.com/auth`.


### PR DESCRIPTION
## Summary

This exposes an optional `configMap.session.cookies[].port` value for generated Authelia URLs.

The option allows Helm users to generate an `authelia_url` with an explicit non-default port, for example:

```yaml
configMap:
  session:
    cookies:
      - domain: example.com
        subdomain: auth
        port: 8443
```

This renders:
authelia_url: 'https://auth.example.com:8443'
The port is only used when building the generated authelia_url. It does not affect the cookie domain.

Changes
- Add configMap.session.cookies[].port to values.
- Add schema coverage for the port field.
- Document the port option in chart values.
- Render the optional port in generated authelia_url.
- Keep the existing host rendering behavior unchanged for ingress hostnames.
- Add CI values coverage for rendering a non-default Authelia URL port.

Validation
helm lint charts/authelia -f charts/authelia/ci/authelia-url-port.yaml
helm template authelia charts/authelia -f charts/authelia/ci/authelia-url-port.yaml
The template output includes:
authelia_url: 'https://auth.example.com:8443'
Related Fixes #412.

This follows the same use case as #361, but includes schema/docs/test coverage and keeps the port scoped to generated authelia_url only.

Pairs with the core Authelia-side support: https://github.com/authelia/authelia/pull/12205