### PR TITLE
feat(authelia): add notifier template path

### DIFF
--- a/charts/authelia/Chart.yaml
+++ b/charts/authelia/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: authelia
-version: 0.11.6
+version: 0.11.7
 kubeVersion: ">= 1.30.0-0"
 description: Authelia is a Single Sign-On Multi-Factor portal for web apps
 type: application
@@ -45,7 +45,7 @@ annotations:
   artifacthub.io/category: security
   artifacthub.io/changes: |
     - kind: added
-      description: Update to Authelia 4.39.20.
+      description: Notifier template path.
   artifacthub.io/images: |
     - name: authelia/authelia
       image: ghcr.io/authelia/authelia:4.39.20

--- a/charts/authelia/README.md
+++ b/charts/authelia/README.md
@@ -1,6 +1,6 @@
 # authelia
 
-![Version: 0.11.6](https://img.shields.io/badge/Version-0.11.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.20](https://img.shields.io/badge/AppVersion-4.39.20-informational?style=flat-square)
+![Version: 0.11.7](https://img.shields.io/badge/Version-0.11.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.20](https://img.shields.io/badge/AppVersion-4.39.20-informational?style=flat-square)
 
 Authelia is a Single Sign-On Multi-Factor portal for web apps
 
@@ -275,6 +275,7 @@ Kubernetes: `>= 1.30.0-0`
 | configMap.notifier.smtp.tls.server_name | string | `""` | The server subject name to check the servers certificate against during the validation process. This option is not required if the certificate has a SAN which matches the host option. |
 | configMap.notifier.smtp.tls.skip_verify | bool | `false` | Skip verifying the server certificate entirely. |
 | configMap.notifier.smtp.username | string | `""` | The username sent for authentication with the SMTP server. Paired with the password. |
+| configMap.notifier.template_path | string | `""` | Path for custom templates for notifications. Not configured by default which uses the embedded templates. The path must exist within the container when configured. See https://www.authelia.com/reference/guides/notification-templates/ |
 | configMap.ntp.address | string | `"udp://time.cloudflare.com:123"` | NTP server address. |
 | configMap.ntp.disable_failure | bool | `false` | The default of false will prevent startup only if we can contact the NTP server and the time is out of sync with the NTP server more than the configured max_desync. If you set this to true, an error will be logged but startup will continue regardless of results. |
 | configMap.ntp.disable_startup_check | bool | `false` | Disables the NTP check on startup entirely. This means Authelia will not contact a remote service at all if you set this to true, and can operate in a truly offline mode. |

--- a/charts/authelia/templates/configMap.yaml
+++ b/charts/authelia/templates/configMap.yaml
@@ -515,6 +515,9 @@ data:
     {{- with $notifier := .Values.configMap.notifier }}
     notifier:
       disable_startup_check: {{ $.Values.configMap.notifier.disable_startup_check }}
+    {{- with $notifier.template_path }}
+      template_path: {{ . | squote }}
+    {{- end }}
     {{- if $notifier.filesystem.enabled }}
       filesystem:
         filename: {{ $notifier.filesystem.filename | squote }}

--- a/charts/authelia/values.local.yaml
+++ b/charts/authelia/values.local.yaml
@@ -3778,6 +3778,12 @@ configMap:
     # @schema
     # required: false
     # @schema
+    # -- Path for custom templates for notifications.
+    template_path: ''
+
+    # @schema
+    # required: false
+    # @schema
     filesystem:
 
       # @schema

--- a/charts/authelia/values.schema.json
+++ b/charts/authelia/values.schema.json
@@ -2884,10 +2884,17 @@
               ],
               "title": "smtp",
               "type": "object"
+            },
+            "template_path": {
+              "default": "",
+              "description": "Path for custom templates for notifications. Not configured by default which uses the embedded templates. The\npath must exist within the container when configured.\nSee https://www.authelia.com/reference/guides/notification-templates/",
+              "title": "template_path",
+              "type": "string"
             }
           },
           "required": [
             "disable_startup_check",
+            "template_path",
             "filesystem",
             "smtp"
           ],

--- a/charts/authelia/values.yaml
+++ b/charts/authelia/values.yaml
@@ -2345,6 +2345,11 @@ configMap:
     # -- You can disable the notifier startup check by setting this to true.
     disable_startup_check: false
 
+    # -- Path for custom templates for notifications. Not configured by default which uses the embedded templates. The
+    # path must exist within the container when configured.
+    # See https://www.authelia.com/reference/guides/notification-templates/
+    template_path: ''
+
     filesystem:
       # -- Enables the File System Provider (Notifier).
       enabled: false


### PR DESCRIPTION

## Description

Adds the `configMap.notifier.template_path` value allowing a path for custom notification templates to be configured. It is empty by default which retains the embedded templates, and is only rendered into the configuration when set.

## Related Issue

Fixes #387 

## Type of Change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Other (please describe)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] The [Code of Conduct](https://www.authelia.com/policies/code-of-conduct/) Has been read and is agreed to by the PR
  author.
- [x] `Chart.yaml` `version` has been bumped for every chart you modified.
- [x] `Chart.yaml` `artifacthub.io/changes` annotation has been updated and describes your change.
- [x] `README.md` was **not** edited directly; `README.md.gotmpl` and/or `values.yaml` were edited instead.
- [x] `values.schema.json` was **not** edited directly; `values.yaml` `# @schema` annotations were edited instead.
- [ ] `make docs schema` has been run and the regenerated files are committed.

`make schema` fails on `master` with 

```zsh
❯ make schema
go install github.com/dadav/helm-schema/cmd/helm-schema@latest
helm-schema -c charts
ERRO[2026-07-30T21:47:23+02:00] Generated schema for chart authelia is invalid: generated schema is not valid: json-pointer in "https://charts.authelia.com/definitions.json#/definitions/io.k8s.api.networking.v1.NetworkPolicyEgressRule" not found 
ERRO[2026-07-30T21:47:23+02:00] Execution error: some errors were found      
make: *** [schema] Error 1
```

and sometimes

```zsh
❯ make schema                              
go install github.com/dadav/helm-schema/cmd/helm-schema@latest
helm-schema -c charts
ERRO[2026-07-30T21:52:23+02:00] Generated schema for chart authelia is invalid: generated schema is not valid: json-pointer in "https://charts.authelia.com/definitions.json#/definitions/io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerBehavior" not found 
ERRO[2026-07-30T21:52:23+02:00] Execution error: some errors were found      
make: *** [schema] Error 1
```

I experience the same errors on this branch.

- [ ] `make lint` passes locally.

`make lint` indirectly calls `make schema`, so this ultimately fails as well, but the actual linting does pass.

- [x] Commit messages and PR title follow Conventional Commits.
- [x] All usage of Generative AI is fully disclosed in the PR description in complete compliance with the
  [Generative AI Guidelines](https://www.authelia.com/contributing/guidelines/introduction/#generative-ai-guidelines).


Not sure if I should bump the minor or patch version. Following the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) rules I should bump minor, but I see patch being bumped in #418 which is a feat-commit as well.